### PR TITLE
ci: main -> master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
CI is not running on merges to `master` because `ci.yml` references `main`