### PR TITLE
Make `#[derive(SchemaRead)]` less brittle with generic lifetimes

### DIFF
--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 darling = "0.21.3"
 proc-macro2 = "1.0.101"
 quote = "1.0.41"
-syn = "2.0.106"
+syn = { version = "2.0.106", features = ["visit-mut"] }


### PR DESCRIPTION
#### Problem 

The `SchemaRead` trait is generic over the lifetime `'de`, to which the `Reader` parameter is also bound in the trait's `read` function.

```rs
pub trait SchemaRead<'de> {
    type Dst;

    fn read(reader: &mut Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()>;
}
```

This ensures that, when performing zero-copy deserialization (i.e., returning a reference into the `Reader`'s byte buffer), the `Reader`'s buffer must live at least as long as the destination's (`dst`) lifetime.

This can present a challenge in the implementation of the `SchemaRead` derive macro. 

For example:

```rs
#[derive(SchemaRead)]
struct HasRef<'a> {
    name: &'a str
}
```
The macro must introduce `'de` and ensure it outlives `'a`.

https://github.com/anza-xyz/wincode/blob/e2b20ccd3c2f262de57816235e2063b21c393b4a/wincode-derive/src/schema_read.rs#L325-L329

Now where this can get tricky is when `read` impls are generated.
```rs
// Generated while iterating through the struct's declared fields.
<&'a str as SchemaRead<'de>>::read(
    reader,
    unsafe { &mut *(&raw mut (*dst_ptr).name).cast::<MaybeUninit<_>>() },
)?;
```

`'de` extends `'a`, but `'a` may not necessarily extend `'de` (i.e., `'a` may not live as long as `'de`).

The way that the macro currently gets around this is by rebinding a type's field lifetime to `'de` during code generation, which ensures that the bytes read in the `read` portion are done so as `'de` (and as such satisfies the requirement that the read bytes live for `'de`).

https://github.com/anza-xyz/wincode/blob/e2b20ccd3c2f262de57816235e2063b21c393b4a/wincode-derive/src/schema_read.rs#L15-L36

This is brittle because it only works for reference types (e.g., `&'a T`). It does _not_ work for types with generic lifetime bounds (e.g., `OtherType<'a>`) because they are represented as distinct AST nodes. This is not ideal, because in principle, there's no reason we shouldn't be able to zero-copy deserialize nested types containing references.

#### Summary of changes

This removes the brittle lifetime rebinding done by matching on a single level `Type`, and instead replaces that functionality with `syn`'s `VisitMut`, which provides recursive mutable access to the AST nodes that comprise a `Type`.