### PR TITLE
`doc_auto_cfg` was merged into `doc_cfg`

### DIFF
--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -253,7 +253,7 @@
 //! |---|---|---|---|
 //! |`with`|`Type`|`None`|Overrides the default `SchemaRead` or `SchemaWrite` implementation for the field.|
 //!
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
docsrs build failed: https://docs.rs/crate/wincode/0.1.0/builds/2572360

Appears that `doc_auto_cfg` was folded into `doc_cfg`

```
# rustc version
rustc 1.92.0-nightly (b6f0945e4 2025-10-08)# docs.rs version
docsrs 0.6.0 (f42173de 2025-09-12)# build log
[INFO] running `Command { std: "docker" "create" "-v" "/home/cratesfyi/workspace-builder/builds/wincode-0.1.0/target:/opt/rustwide/target:rw,Z" "-v" "/home/cratesfyi/workspace-builder/builds/wincode-0.1.0/source:/opt/rustwide/workdir:ro,Z" "-v" "/home/cratesfyi/workspace-builder/cargo-home:/opt/rustwide/cargo-home:ro,Z" "-v" "/home/cratesfyi/workspace-builder/rustup-home:/opt/rustwide/rustup-home:ro,Z" "-e" "SOURCE_DIR=/opt/rustwide/workdir" "-e" "CARGO_TARGET_DIR=/opt/rustwide/target" "-e" "DOCS_RS=1" "-e" "CARGO_HOME=/opt/rustwide/cargo-home" "-e" "RUSTUP_HOME=/opt/rustwide/rustup-home" "-w" "/opt/rustwide/workdir" "-m" "6442450944" "--cpus" "6" "--user" "1001:1001" "--network" "none" "ghcr.io/rust-lang/crates-build-env/linux@sha256:e90291280db7d1fac5b66fc6dad9f9662629e7365a55743daf9bdf73ebc4ea79" "/opt/rustwide/cargo-home/bin/cargo" "+nightly" "rustdoc" "--lib" "-Zrustdoc-map" "--all-features" "--config" "build.rustdocflags=[\"--cfg\", \"docsrs\", \"--cfg\", \"docsrs\", \"-D\", \"warnings\", \"-Z\", \"unstable-options\", \"--emit=invocation-specific\", \"--resource-suffix\", \"-20251008-1.92.0-nightly-b6f0945e4\", \"--static-root-path\", \"/-/rustdoc.static/\", \"--cap-lints\", \"warn\", \"--extern-html-root-takes-precedence\"]" "--offline" "-Zunstable-options" "--config=doc.extern-map.registries.crates-io=\"https://docs.rs/{pkg_name}/{version}/x86_64-unknown-linux-gnu\"" "-Zrustdoc-scrape-examples" "-j6" "--target" "x86_64-unknown-linux-gnu", kill_on_drop: false }`
[INFO] [stderr] WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
[INFO] [stdout] 1e4de5b867edde1aa02b65a86c36c0a7f4c401fd5686648e68aba7aa0bb0cbe1
[INFO] running `Command { std: "docker" "start" "-a" "1e4de5b867edde1aa02b65a86c36c0a7f4c401fd5686648e68aba7aa0bb0cbe1", kill_on_drop: false }`
[INFO] [stderr] warning: target filter specified, but no targets matched; this is a no-op
[INFO] [stderr]  Documenting wincode v0.1.0 (/opt/rustwide/workdir)
[INFO] [stderr] error[E0557]: feature has been removed
[INFO] [stderr]    --> src/lib.rs:256:38
[INFO] [stderr]     |
[INFO] [stderr] 256 | #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
[INFO] [stderr]     |                                      ^^^^^^^^^^^^ feature has been removed
[INFO] [stderr]     |
[INFO] [stderr]     = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
[INFO] [stderr]     = note: merged into `doc_cfg`
[INFO] [stderr] 
[INFO] [stderr] error: Compilation failed, aborting rustdoc
[INFO] [stderr] 
[INFO] [stderr] For more information about this error, try `rustc --explain E0557`.
[INFO] [stderr] error: could not document `wincode`
[INFO] running `Command { std: "docker" "inspect" "1e4de5b867edde1aa02b65a86c36c0a7f4c401fd5686648e68aba7aa0bb0cbe1", kill_on_drop: false }`
[INFO] running `Command { std: "docker" "rm" "-f" "1e4de5b867edde1aa02b65a86c36c0a7f4c401fd5686648e68aba7aa0bb0cbe1", kill_on_drop: false }`
[INFO] [stdout] 1e4de5b867edde1aa02b65a86c36c0a7f4c401fd5686648e68aba7aa0bb0cbe1
```