### PR TITLE
v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "proptest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ arithmetic_side_effects = "deny"
 warnings = "deny"
 
 [workspace.package]
-version = "0.1.0"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/wincode"
 homepage = "https://anza.xyz/"

--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode-derive"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 description = "Derive macros for wincode"
 repository.workspace = true

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 description = "Fast bincode de/serialization with placement initialization"
 repository.workspace = true


### PR DESCRIPTION
- Fix docsrs build for `wincode` #5
- Make #[derive(SchemaRead)] less brittle with generic lifetimes #4
