### PR TITLE
Implement specialization for contiguous byte structures

### DIFF
--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -268,5 +268,6 @@ mod serde;
 pub use serde::*;
 #[cfg(test)]
 mod proptest_config;
+mod util;
 #[cfg(feature = "derive")]
 pub use wincode_derive::*;

--- a/wincode/src/util.rs
+++ b/wincode/src/util.rs
@@ -1,0 +1,35 @@
+use core::{any::TypeId, marker::PhantomData, mem::transmute};
+
+/// Ripped from the `unty` crate, but forced inline so the compiler can DCE the branch.
+#[inline(always)]
+pub(crate) fn type_equal<Src: ?Sized, Target: ?Sized>() -> bool {
+    non_static_type_id::<Src>() == non_static_type_id::<Target>()
+}
+
+// Code by dtolnay in a bincode issue:
+// https://github.com/bincode-org/bincode/issues/665#issue-1903241159
+//
+// All functions ripped from the `unty` crate, forced inline for branch DCE.
+#[inline(always)]
+fn non_static_type_id<T: ?Sized>() -> TypeId {
+    trait NonStaticAny {
+        fn get_type_id(&self) -> TypeId
+        where
+            Self: 'static;
+    }
+
+    impl<T: ?Sized> NonStaticAny for PhantomData<T> {
+        #[inline(always)]
+        fn get_type_id(&self) -> TypeId
+        where
+            Self: 'static,
+        {
+            TypeId::of::<T>()
+        }
+    }
+
+    let phantom_data = PhantomData::<T>;
+    NonStaticAny::get_type_id(unsafe {
+        transmute::<&dyn NonStaticAny, &(dyn NonStaticAny + 'static)>(&phantom_data)
+    })
+}


### PR DESCRIPTION
Users must currently opt into direct buffer reads / writes with `Pod`, and `#[wincode(with)]` makes that easy enough. But, it would be nice if the library just "did the right thing" when it can tell that the src / dst type is `u8`.

This steals some logic from the [`unty`](https://crates.io/crates/unty) crate, but force inlines it so the compiler can reliably DCE the branch (it does not reliably do so when importing the crate). I have verified that indeed the compiler is able to eliminate the branch: https://rust.godbolt.org/z/1WMY8qn8K, which means the types that use this (basically all contiguous data structures (vec, arrays, etc) shouldn't have any runtime overhead with this check.

E.g., the following type should opt into these optimizations

```rs
#[derive(SchemaWrite, SchemaRead)]
struct MyStruct {
    bytes: Vec<u8>,
    signature: [u8; 64]
}
```