### PR TITLE
Add `SchemaRead` impl for `&'de [u8]`

### DIFF
--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -393,6 +393,17 @@ where
     }
 }
 
+impl<'de> SchemaRead<'de> for &'de [u8] {
+    type Dst = &'de [u8];
+
+    #[inline]
+    fn read(reader: &mut Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let len = <BincodeLen>::read::<u8>(reader)?;
+        dst.write(reader.read_borrowed(len)?);
+        Ok(())
+    }
+}
+
 impl<'de, T, const N: usize> SchemaRead<'de> for [T; N]
 where
     T: SchemaRead<'de>,

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -614,6 +614,28 @@ mod tests {
         assert!(bincode::deserialize::<()>(&bincode_serialized).is_ok());
     }
 
+    #[test]
+    fn test_borrowed_bytes() {
+        #[derive(
+            SchemaWrite, SchemaRead, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+        )]
+        #[wincode(internal)]
+        struct BorrowedBytes<'a> {
+            bytes: &'a [u8],
+        }
+
+        proptest!(proptest_cfg(), |(bytes in proptest::collection::vec(any::<u8>(), 0..=100))| {
+            let val = BorrowedBytes { bytes: &bytes };
+            let bincode_serialized = bincode::serialize(&val).unwrap();
+            let schema_serialized = serialize(&val).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: BorrowedBytes = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: BorrowedBytes = deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&val, &bincode_deserialized);
+            prop_assert_eq!(val, schema_deserialized);
+        });
+    }
+
     proptest! {
         #![proptest_config(proptest_cfg())]
 


### PR DESCRIPTION
This adds zero-copy `&'a [u8]` deserialization. 

I did not include this before because the `SchemaWrite` impl would necessarily use the blanket `[T]` impl, which visits and writes individual slice elements.

https://github.com/anza-xyz/wincode/blob/e0dea9fe01c2dd9552283d69a1931c12f2e6df57/wincode/src/schema/impls.rs#L378-L394

With #7, this will use the optimized single memcpy path