### PR TITLE
Add Cursor and Vec Reader/Writer impls

### DIFF
--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -360,13 +360,19 @@ mod vec {
 /// Trusted writer for `Cursor<&mut Vec<u8>>` or `Cursor<Vec<u8>>` that continues
 /// overwriting the vector's memory.
 ///
-/// This will _not_ grow the vector, as it assumes the caller has already reserved enough capacity.
+/// Generally this should not be constructed directly, but rather by calling [`Writer::as_trusted_for`]
+/// on a trusted [`Writer`]. This will ensure that the safety invariants are upheld.
 ///
 /// Note that this does *not* update the length of the vector, as it only contains a reference to the
 /// vector's memory via `&mut [MaybeUninit<u8>]`, but it will update the _position_ of the cursor.
 /// Vec implementations will synchronize the length and position on subsequent writes or when the
 /// writer is finished. Benchmarks showed a roughly 2x performance improvement using this method
 /// rather than taking a `&mut Vec<u8>` directly.
+///
+/// # Safety
+///
+/// - This will _not_ grow the vector, as it assumes the caller has already reserved enough capacity.
+///   The `inner` buffer must have sufficient capacity for all writes. It is UB if this is not upheld.
 #[cfg(feature = "alloc")]
 pub struct TrustedVecWriter<'a> {
     inner: &'a mut [MaybeUninit<u8>],

--- a/wincode/src/io/mod.rs
+++ b/wincode/src/io/mod.rs
@@ -41,6 +41,10 @@ const fn read_size_limit(len: usize) -> ReadError {
 /// Returns [`ReadError::UnsupportedZeroCopy`] for readers that do not support zero-copy.
 pub trait Reader<'a> {
     /// A variant of the [`Reader`] that can elide bounds checking within a given window.
+    ///
+    /// Trusted variants of the [`Reader`] should generally not be constructed directly,
+    /// but rather by calling [`Reader::as_trusted_for`] on a trusted [`Reader`].
+    /// This will ensure that the safety invariants are upheld.
     type Trusted<'b>: Reader<'a>
     where
         Self: 'b;
@@ -205,6 +209,10 @@ pub type WriteResult<T> = core::result::Result<T, WriteError>;
 /// Trait for structured writing of bytes into a source of potentially uninitialized memory.
 pub trait Writer {
     /// A variant of the [`Writer`] that can elide bounds checking within a given window.
+    ///
+    /// Trusted variants of the [`Writer`] should generally not be constructed directly,
+    /// but rather by calling [`Writer::as_trusted_for`] on a trusted [`Writer`].
+    /// This will ensure that the safety invariants are upheld.
     type Trusted<'a>: Writer
     where
         Self: 'a;

--- a/wincode/src/io/slice.rs
+++ b/wincode/src/io/slice.rs
@@ -38,9 +38,12 @@ pub(crate) mod trusted_slice {
 
 /// In-memory [`Reader`] that does not perform bounds checking, with zero-copy support.
 ///
-/// Methods will panic if reads go out of bounds, so ensure that
-/// the chain of [`SchemaRead`](crate::SchemaRead) implementations that
-/// follow have statically known read requirements.
+/// Generally this should not be constructed directly, but rather by calling [`Reader::as_trusted_for`]
+/// on a trusted [`Reader`]. This will ensure that the safety invariants are upheld.
+///
+/// # Safety
+///
+/// - The inner buffer must have sufficient capacity for all reads. It is UB if this is not upheld.
 pub struct TrustedSliceReaderZeroCopy<'a> {
     cursor: &'a [u8],
 }
@@ -93,11 +96,14 @@ impl<'a> Reader<'a> for TrustedSliceReaderZeroCopy<'a> {
 
 /// In-memory [`Reader`] that does not perform bounds checking.
 ///
+/// Generally this should not be constructed directly, but rather by calling [`Reader::as_trusted_for`]
+/// on a trusted [`Reader`]. This will ensure that the safety invariants are upheld.
+///
 /// Use [`TrustedSliceReaderZeroCopy`] for zero-copy support.
 ///
-/// Methods will panic if reads go out of bounds, so ensure that
-/// the chain of [`SchemaRead`](crate::SchemaRead) implementations that
-/// follow have statically known read requirements.
+/// # Safety
+///
+/// - The inner buffer must have sufficient capacity for all reads. It is UB if this is not upheld.
 pub struct TrustedSliceReader<'a, 'b> {
     cursor: &'b [u8],
     _marker: PhantomData<&'a ()>,
@@ -198,9 +204,12 @@ impl<'a> Reader<'a> for &'a [u8] {
 
 /// In-memory [`Writer`] that does not perform bounds checking.
 ///
-/// Methods will panic if writes go out of bounds, so ensure that
-/// the chain of [`SchemaWrite`](crate::SchemaWrite) implementations that
-/// follow have statically known size requirements.
+/// Generally this should not be constructed directly, but rather by calling [`Writer::as_trusted_for`]
+/// on a trusted [`Writer`]. This will ensure that the safety invariants are upheld.
+///
+/// # Safety
+///
+/// - The inner buffer must have sufficient capacity for all writes. It is UB if this is not upheld.
 pub struct TrustedSliceWriter<'a> {
     buffer: &'a mut [MaybeUninit<u8>],
 }

--- a/wincode/src/io/vec.rs
+++ b/wincode/src/io/vec.rs
@@ -2,7 +2,14 @@ use super::*;
 
 /// Trusted writer for `Vec<u8>` that continues appending to the vector's spare capacity.
 ///
-/// This will _not_ grow the vector, as it assumes the caller has already reserved enough capacity.
+/// Generally this should not be constructed directly, but rather by calling [`Writer::as_trusted_for`]
+/// on a [`Vec<u8>`]. This will ensure that the safety invariants are upheld.
+///
+/// # Safety
+///
+/// - This will _not_ grow the vector, and it will not bounds check writes, as it assumes the caller has
+///   already reserved enough capacity. The `inner` Vec must have sufficient capacity for all writes.
+///   It is UB if this is not upheld.
 pub struct TrustedVecWriter<'a> {
     inner: &'a mut Vec<u8>,
 }


### PR DESCRIPTION
Some quality of life implementations for `Reader` and `Writer`.

#16 adds the barebones necessary implementations of `Reader` and `Writer` over slices, but practically speaking users will want more ergonomics when interfacing with `wincode`; for example being able to serialize into a `Vec`, or being able to serialize _multiple_ times into a `Vec` (like [`std::io::Cursor<&mut Vec>`](https://doc.rust-lang.org/std/io/struct.Cursor.html#impl-Write-for-Cursor%3C%26mut+Vec%3Cu8,+A%3E%3E) provides).

This adds a new `Cursor` struct, and the following implementations:
- `Reader for Cursor<T> where T: AsRef<[u8]>`
- `Writer for Cursor<&mut [MaybeUninit<u8>]>`
- `Writer for Cursor<&mut MaybeUninit<[u8; N]>>`
- `Writer for Cursor<&mut Vec<u8>>`
- `Writer for Cursor<Vec<u8>>`

This allows serializing / deserializing into / from the same source multiple times or from specific offsets in the source.

Also included is a `Writer for Vec<u8>` implementation, which simply appends to the `Vec` (like [`std::io::Write`'s implementation](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-Write-for-Vec%3Cu8,+A%3E)).