### PR TITLE
Allow specifying custom enum discriminant encodings

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -403,13 +403,24 @@ pub(crate) struct SchemaArgs {
     /// Specifies whether to generate placement initialization struct helpers on `SchemaRead` implementations.
     #[darling(default)]
     pub(crate) struct_extensions: bool,
-    /// Specifies the encoding to use for enum variants.
+    /// Specifies the encoding to use for enum discriminants.
     ///
-    /// If specified, the enum variants will be encoded using the given type's `SchemaWrite`
+    /// If specified, the enum discriminants will be encoded using the given type's `SchemaWrite`
     /// and `SchemaRead` implementations.
-    /// Otherwise, the enum variants will be encoded using the default encoding (`u32`).
+    /// Otherwise, the enum discriminants will be encoded using the default encoding (`u32`).
     #[darling(default)]
-    pub(crate) variant_encoding: Option<Type>,
+    pub(crate) tag_encoding: Option<Type>,
+}
+
+/// The default encoding to use for enum discriminants.
+///
+/// Bincode's default discriminant encoding is `u32`.
+///
+/// Note in the public APIs we refer to `tag` to mean the discriminant encoding
+/// for friendlier naming.
+#[inline]
+pub(crate) fn default_tag_encoding() -> Type {
+    parse_quote!(u32)
 }
 
 /// Metadata about the `#[repr]` attribute on a struct.

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -1,7 +1,7 @@
 use {
     crate::common::{
-        extract_repr, get_crate_name, get_src_dst, suppress_unused_fields, Field, FieldsExt,
-        SchemaArgs, StructRepr, TraitImpl, Variant,
+        default_tag_encoding, extract_repr, get_crate_name, get_src_dst, suppress_unused_fields,
+        Field, FieldsExt, SchemaArgs, StructRepr, TraitImpl, Variant,
     },
     darling::{
         ast::{Data, Fields, Style},
@@ -66,14 +66,13 @@ fn impl_struct(
 fn impl_enum(
     enum_ident: &Type,
     variants: &[Variant],
-    variant_encoding: Option<&Type>,
+    tag_encoding: Option<&Type>,
 ) -> (TokenStream, TokenStream, TokenStream) {
     if variants.is_empty() {
         return (quote! {Ok(0)}, quote! {Ok(())}, quote! {TypeMeta::Dynamic});
     }
-    // Bincode always encodes the discriminant as u32.
-    let default_variant_encoding = parse_quote!(u32);
-    let variant_encoding = variant_encoding.unwrap_or(&default_variant_encoding);
+    let default_tag_encoding = default_tag_encoding();
+    let tag_encoding = tag_encoding.unwrap_or(&default_tag_encoding);
     let mut size_of_impl = Vec::with_capacity(variants.len());
     let mut write_impl = Vec::with_capacity(variants.len());
     // Note that all enums except unit enums are never static.
@@ -82,7 +81,7 @@ fn impl_enum(
         // If all variants are unit, we know up front that the static size is the size of the discriminant.
         type_meta_impl = quote! {
             const {
-                match <#variant_encoding as SchemaWrite>::TYPE_META {
+                match <#tag_encoding as SchemaWrite>::TYPE_META {
                     // Unit enums are never zero-copy, as they have invalid bit patterns.
                     TypeMeta::Static { size, .. } => TypeMeta::Static { size, zero_copy: false },
                     TypeMeta::Dynamic => TypeMeta::Dynamic,
@@ -97,10 +96,10 @@ fn impl_enum(
         let discriminant = variant.discriminant(i);
         // Bincode always encodes the discriminant using the index of the field order.
         let size_of_discriminant = quote! {
-            #variant_encoding::size_of(&#discriminant)?
+            #tag_encoding::size_of(&#discriminant)?
         };
         let write_discriminant = quote! {
-            #variant_encoding::write(writer, &#discriminant)?;
+            #tag_encoding::write(writer, &#discriminant)?;
         };
 
         let (size, write) = match fields.style {
@@ -143,7 +142,7 @@ fn impl_enum(
                 (
                     quote! {
                         #match_case => {
-                            if let (TypeMeta::Static { size: disc_size, .. } #(,TypeMeta::Static { size: #static_anon_idents, .. })*) = (<#variant_encoding as SchemaWrite>::TYPE_META #(,#static_targets)*) {
+                            if let (TypeMeta::Static { size: disc_size, .. } #(,TypeMeta::Static { size: #static_anon_idents, .. })*) = (<#tag_encoding as SchemaWrite>::TYPE_META #(,#static_targets)*) {
                                 return Ok(disc_size + #(#static_anon_idents)+*);
                             }
 
@@ -156,7 +155,7 @@ fn impl_enum(
                     },
                     quote! {
                         #match_case => {
-                            if let (TypeMeta::Static { size: disc_size, .. } #(,TypeMeta::Static { size: #static_anon_idents, .. })*) = (<#variant_encoding as SchemaWrite>::TYPE_META #(,#static_targets)*) {
+                            if let (TypeMeta::Static { size: disc_size, .. } #(,TypeMeta::Static { size: #static_anon_idents, .. })*) = (<#tag_encoding as SchemaWrite>::TYPE_META #(,#static_targets)*) {
                                 let writer = &mut writer.as_trusted_for(disc_size + #(#static_anon_idents)+*)?;
                                 #write_discriminant;
                                 #(#write)*
@@ -219,10 +218,8 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
 
     let (size_of_impl, write_impl, type_meta_impl) = match &args.data {
         Data::Struct(fields) => {
-            if args.variant_encoding.is_some() {
-                return Err(Error::custom(
-                    "`variant_encoding` is only supported for enums",
-                ));
+            if args.tag_encoding.is_some() {
+                return Err(Error::custom("`tag_encoding` is only supported for enums"));
             }
             // Only structs are eligible being marked zero-copy, so only the struct
             // impl needs the repr.
@@ -233,7 +230,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
                 Some(from) => from,
                 None => &parse_quote!(Self),
             };
-            impl_enum(enum_ident, v, args.variant_encoding.as_ref())
+            impl_enum(enum_ident, v, args.tag_encoding.as_ref())
         }
     };
 

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -228,7 +228,7 @@
 //! |`from`|`Type`|`None`|Indicates that type is a mapping from another type (example in previous section)|
 //! |`no_suppress_unused`|`bool`|`false`|Disable unused field lints suppression. Only usable on structs with `from`.|
 //! |`struct_extensions`|`bool`|`false`|Generates placement initialization helpers on `SchemaRead` struct implementations|
-//! |`variant_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
+//! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
 //!
 //! ### `no_suppress_unused`
 //!
@@ -243,7 +243,7 @@
 //!
 //! Note that this only works on structs, as it is not possible to construct an arbitrary enum variant.
 //!
-//! ### `variant_encoding`
+//! ### `tag_encoding`
 //!
 //! Allows specifying the encoding/decoding schema to use for the variant discriminant. Only usable on enums.
 //!
@@ -261,7 +261,7 @@
 //!
 //! # #[derive(Debug, PartialEq, Eq)]
 //! #[derive(SchemaWrite, SchemaRead)]
-//! #[wincode(variant_encoding = "u8")]
+//! #[wincode(tag_encoding = "u8")]
 //! enum Enum {
 //!     A,
 //!     B,

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -732,9 +732,9 @@ mod tests {
     }
 
     #[test]
-    fn enum_with_variant_encoding_roundtrip() {
+    fn enum_with_tag_encoding_roundtrip() {
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, proptest_derive::Arbitrary)]
-        #[wincode(internal, variant_encoding = "u8")]
+        #[wincode(internal, tag_encoding = "u8")]
         enum Enum {
             A { name: String, id: u64 },
             B(String, Vec<u8>),
@@ -779,9 +779,9 @@ mod tests {
     }
 
     #[test]
-    fn unit_enum_with_variant_encoding_static_size() {
+    fn unit_enum_with_tag_encoding_static_size() {
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
-        #[wincode(internal, variant_encoding = "u8")]
+        #[wincode(internal, tag_encoding = "u8")]
         enum Enum {
             A,
             B,
@@ -833,9 +833,9 @@ mod tests {
     }
 
     #[test]
-    fn enum_variant_encoding() {
+    fn enum_tag_encoding() {
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, proptest_derive::Arbitrary)]
-        #[wincode(internal, variant_encoding = "u8")]
+        #[wincode(internal, tag_encoding = "u8")]
         enum EnumU8 {
             A,
             B,
@@ -849,7 +849,7 @@ mod tests {
         });
 
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, proptest_derive::Arbitrary)]
-        #[wincode(internal, variant_encoding = "u8")]
+        #[wincode(internal, tag_encoding = "u8")]
         enum EnumTupleU8 {
             A(u64),
             B(StructStatic),
@@ -867,7 +867,7 @@ mod tests {
         });
 
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, proptest_derive::Arbitrary)]
-        #[wincode(internal, variant_encoding = "u8")]
+        #[wincode(internal, tag_encoding = "u8")]
         enum EnumRecordU8 {
             A { id: u64 },
             B { data: StructStatic },


### PR DESCRIPTION
We have various cases in agave and alpenglow where the default serde/bincode enum discriminant encoding is overridden to use something like a `u8`. This is currently unsupported in `wincode-derive`, requiring users to manually implement `SchemaRead` / `SchemaWrite` for those enums.

This PR adds another top-level derive attribute that allows specifying the schema to use when encoding enum discriminants. Any type that implements `SchemaRead` and `SchemaWrite` is supported, so the user is free to use any built-in type or their own custom encoding.

Note this also includes: #23 

#### Custom encoding
```rs
#[wincode(tag_encoding = "u8")]
enum Enum {
    A { name: String, id: u64 },
    B(String, Vec<u8>),
    C,
}
```

#### Custom tag
```rs
enum Enum {
    #[wincode(tag = 1)]
    A { name: String, id: u64 },
    #[wincode(tag = 2)]
    B(String, Vec<u8>),
    #[wincode(tag = 3)]
    C,
}
```