### PR TITLE
Support custom variant tags

### DIFF
--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -8,9 +8,9 @@ use {
         ast::{Data, Fields, Style},
         Error, FromDeriveInput, Result,
     },
-    proc_macro2::{Span, TokenStream},
+    proc_macro2::TokenStream,
     quote::{format_ident, quote},
-    syn::{parse_quote, DeriveInput, GenericParam, Generics, LitInt, Type},
+    syn::{parse_quote, DeriveInput, GenericParam, Generics, Type},
 };
 
 fn impl_struct(
@@ -266,7 +266,7 @@ fn impl_enum(
     let read_impl = variants.iter().enumerate().map(|(i, variant)| {
         let variant_ident = &variant.ident;
         let fields = &variant.fields;
-        let discriminant = LitInt::new(&i.to_string(), Span::call_site());
+        let discriminant = variant.discriminant(i);
 
         match fields.style {
             style @ (Style::Struct | Style::Tuple) => {

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -7,9 +7,9 @@ use {
         ast::{Data, Fields, Style},
         Error, FromDeriveInput, Result,
     },
-    proc_macro2::{Span, TokenStream},
+    proc_macro2::TokenStream,
     quote::quote,
-    syn::{parse_quote, DeriveInput, LitInt, Type},
+    syn::{parse_quote, DeriveInput, Type},
 };
 
 fn impl_struct(
@@ -94,7 +94,7 @@ fn impl_enum(
     for (i, variant) in variants.iter().enumerate() {
         let variant_ident = &variant.ident;
         let fields = &variant.fields;
-        let discriminant = LitInt::new(&i.to_string(), Span::call_site());
+        let discriminant = variant.discriminant(i);
         // Bincode always encodes the discriminant using the index of the field order.
         let size_of_discriminant = quote! {
             #variant_encoding::size_of(&#discriminant)?

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -368,6 +368,40 @@
 //! |---|---|---|---|
 //! |`with`|`Type`|`None`|Overrides the default `SchemaRead` or `SchemaWrite` implementation for the field.|
 //!
+//! ## Variant level (enum variants)
+//! |Attribute|Type|Default|Description
+//! |---|---|---|---|
+//! |`tag`|`Expr`|`None`|Specifies the discriminant expression for the variant. Only usable on enums.|
+//!
+//! ### `tag`
+//!
+//! Specifies the discriminant expression for the variant. Only usable on enums.
+//!
+//! <div class="warning">
+//! There is no bincode analog to this attribute.
+//! Specifying this attribute will make your enum incompatible with bincode's default enum encoding.
+//! If you need strict bincode compatibility, you should implement a custom <code>Deserialize</code> and
+//! <code>Serialize</code> impl for your enum on the serde / bincode side.
+//! </div>
+//!
+//! Example:
+//! ```
+//! # #[cfg(any(feature = "derive", feature = "alloc"))] {
+//! use wincode::{SchemaWrite, SchemaRead};
+//!
+//! #[derive(SchemaWrite, SchemaRead)]
+//! enum Enum {
+//!     #[wincode(tag = 5)]
+//!     A,
+//!     #[wincode(tag = 8)]
+//!     B,
+//!     #[wincode(tag = 13)]
+//!     C,
+//! }
+//!
+//! assert_eq!(&wincode::serialize(&Enum::A).unwrap(), &5u32.to_le_bytes());
+//! # }
+//! ```
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Building on #22, this allows overriding the default discriminant value used when encoding an enum's variant and when decoding the discriminant to match the variant.