### PR TITLE
Include padding check in zero_copy qualification

### DIFF
--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -175,8 +175,9 @@ pub struct Elem<T>(PhantomData<T>);
 /// # Safety
 ///
 /// - The type must allow any bit pattern (e.g., no `bool`s, no `char`s, etc.)
-/// - If used on a compound type like a struct or tuple, all fields must be also be `Pod` and its
-///   layout must be guaranteed (via `#[repr(transparent)]` or `#[repr(C)]`).
+/// - If used on a compound type like a struct, all fields must be also be `Pod`, its
+///   layout must be guaranteed (via `#[repr(transparent)]` or `#[repr(C)]`), and the struct
+///   must not have any padding.
 /// - Must not contain references or pointers (includes types like `Vec` or `Box`).
 ///     - Note, you may use `Pod` *inside* types like `Vec` or `Box`, e.g., `Vec<Pod<T>>` or `Box<[Pod<T>]>`,
 ///       but specifying `Pod` on the outer type is invalid.

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -798,6 +798,36 @@ mod tests {
         });
     }
 
+    #[test]
+    fn test_zero_copy_padding_disqualification() {
+        #[derive(SchemaWrite, SchemaRead)]
+        #[wincode(internal)]
+        #[repr(C, align(4))]
+        struct Padded {
+            a: u8,
+        }
+
+        assert!(matches!(
+            <Padded as SchemaWrite>::TYPE_META,
+            TypeMeta::Static {
+                // Serialized size is still the size of the byte, not the in-memory size.
+                size: 1,
+                // Padding disqualifies the type from zero-copy optimization.
+                zero_copy: false
+            }
+        ));
+
+        assert!(matches!(
+            <Padded as SchemaRead<'_>>::TYPE_META,
+            TypeMeta::Static {
+                // Serialized size is still the size of the byte, not the in-memory size.
+                size: 1,
+                // Padding disqualifies the type from zero-copy optimization.
+                zero_copy: false
+            }
+        ));
+    }
+
     proptest! {
         #![proptest_config(proptest_cfg())]
 


### PR DESCRIPTION
In the derive macro, we currently determine whether a struct qualifies for zero-copy by checking that the `repr` is `C` or `transparent` and all its fields are also `zero_copy: true`.

This PR adds an additional qualification: the struct's serialized size must equal its in-memory size; i.e., it has no padding. The importance of this is twofold:
1. Bincode never serializes padding, so we must enforce this to uphold our default bincode-compatible promise.
2. Soundness; implementations are free to serialize zero-copy types using their direct in-memory representation. `SchemaRead` implementations may use the `size` field of `TypeMeta` to read a fixed number of bytes and memcpy those bytes directly into the destination. If `T::TypeMeta::Static {size} != size_of::<T>()` (the serialized size != the in-memory size) that memcpy will not fully initialize the type.

This additional check solves both of these issues.