### PR TITLE
Make trusted reader/writer variants private + `unsafe as_trusted_for`

### DIFF
--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -117,7 +117,11 @@ fn impl_struct(
 
             match <Self as SchemaRead<'de>>::TYPE_META {
                 TypeMeta::Static { size, .. } => {
-                    let reader = &mut reader.as_trusted_for(size)?;
+                    // SAFETY: `size` is the serialized size of the struct, which is the sum
+                    // of the serialized sizes of the fields.
+                    // Calling `read` on each field will consume exactly `size` bytes,
+                    // fully consuming the trusted window.
+                    let reader = &mut unsafe { reader.as_trusted_for(size) }?;
                     #(#read_impl)*
                 }
                 _ => {
@@ -310,7 +314,12 @@ fn impl_enum(
                 quote! {
                     #discriminant => {
                         if let (#(TypeMeta::Static { size: #static_anon_idents, .. }),*) = (#(#static_targets),*) {
-                            let reader = &mut reader.as_trusted_for(#(#static_anon_idents)+*)?;
+                            let summed_sizes = #(#static_anon_idents)+*;
+                            // SAFETY: `summed_sizes` is the sum of the static sizes of the fields,
+                            // which is the serialized size of the variant.
+                            // Calling `read` on each field will consume exactly `summed_sizes` bytes,
+                            // fully consuming the trusted window.
+                            let reader = &mut unsafe { reader.as_trusted_for(summed_sizes) }?;
                             #(#read)*
                             dst.write(#constructor);
                         } else {

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -49,7 +49,11 @@ fn impl_struct(
         quote! {
             match <Self as SchemaWrite>::TYPE_META {
                 TypeMeta::Static { size, .. } => {
-                    let writer = &mut writer.as_trusted_for(size)?;
+                    // SAFETY: `size` is the serialized size of the struct, which is the sum
+                    // of the serialized sizes of the fields.
+                    // Calling `write` on each field will write exactly `size` bytes,
+                    // fully initializing the trusted window.
+                    let writer = &mut unsafe { writer.as_trusted_for(size) }?;
                     #(#writes)*
                     writer.finish()?;
                 }
@@ -156,7 +160,12 @@ fn impl_enum(
                     quote! {
                         #match_case => {
                             if let (TypeMeta::Static { size: disc_size, .. } #(,TypeMeta::Static { size: #static_anon_idents, .. })*) = (<#tag_encoding as SchemaWrite>::TYPE_META #(,#static_targets)*) {
-                                let writer = &mut writer.as_trusted_for(disc_size + #(#static_anon_idents)+*)?;
+                                let summed_sizes = disc_size + #(#static_anon_idents)+*;
+                                // SAFETY: `summed_sizes` is the sum of the static sizes of the fields + the discriminant size,
+                                // which is the serialized size of the variant.
+                                // Writing the discriminant and then calling `write` on each field will write
+                                // exactly `summed_sizes` bytes, fully initializing the trusted window.
+                                let writer = &mut unsafe { writer.as_trusted_for(summed_sizes) }?;
                                 #write_discriminant;
                                 #(#write)*
                                 writer.finish()?;

--- a/wincode/src/io/vec.rs
+++ b/wincode/src/io/vec.rs
@@ -38,7 +38,7 @@ impl<'a> Writer for TrustedVecWriter<'a> {
         Ok(())
     }
 
-    fn as_trusted_for(&mut self, _n_bytes: usize) -> WriteResult<Self::Trusted<'_>> {
+    unsafe fn as_trusted_for(&mut self, _n_bytes: usize) -> WriteResult<Self::Trusted<'_>> {
         Ok(TrustedVecWriter::new(self.inner))
     }
 }
@@ -82,7 +82,7 @@ impl Writer for Vec<u8> {
     }
 
     #[inline]
-    fn as_trusted_for(&mut self, n_bytes: usize) -> WriteResult<Self::Trusted<'_>> {
+    unsafe fn as_trusted_for(&mut self, n_bytes: usize) -> WriteResult<Self::Trusted<'_>> {
         self.reserve(n_bytes);
         // `TrustedVecWriter` will update the length of the vector as it writes.
         Ok(TrustedVecWriter::new(self))
@@ -119,14 +119,12 @@ mod tests {
             let quarter = half / 2;
             vec.write(&bytes[..half]).unwrap();
 
-            let mut t1 = vec
-                .as_trusted_for(bytes.len() - half)
-                .unwrap();
+            let mut t1 = unsafe { vec.as_trusted_for(bytes.len() - half) }.unwrap();
             t1
                 .write(&bytes[half..half + quarter])
                 .unwrap();
 
-            let mut t2 = t1.as_trusted_for(quarter).unwrap();
+            let mut t2 = unsafe { t1.as_trusted_for(quarter) }.unwrap();
             t2.write(&bytes[half + quarter..]).unwrap();
 
             prop_assert_eq!(vec, bytes);
@@ -139,14 +137,12 @@ mod tests {
             let quarter = half / 2;
             vec.write(&bytes[..half]).unwrap();
 
-            let mut t1 = vec
-                .as_trusted_for(bytes.len() - half)
-                .unwrap();
+            let mut t1 = unsafe { vec.as_trusted_for(bytes.len() - half) }.unwrap();
             t1
                 .write(&bytes[half..half + quarter])
                 .unwrap();
 
-            let mut t2 = t1.as_trusted_for(quarter).unwrap();
+            let mut t2 = unsafe { t1.as_trusted_for(quarter) }.unwrap();
             t2.write(&bytes[half + quarter..]).unwrap();
 
             prop_assert_eq!(&vec[..5], &[0; 5]);

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -448,7 +448,9 @@ where
         let base = dst.as_mut_ptr();
         let mut guard = SliceDropGuard::<T::Dst>::new(base);
         if let TypeMeta::Static { size, .. } = Self::TYPE_META {
-            let reader = &mut reader.as_trusted_for(size)?;
+            // SAFETY: `Self::TYPE_META` specifies a static size, which is `N * static_size_of(T)`.
+            // `N` reads of `T` will consume `size` bytes, fully consuming the trusted window.
+            let reader = &mut unsafe { reader.as_trusted_for(size) }?;
             for i in 0..N {
                 let slot = unsafe { &mut *base.add(i) };
                 T::read(reader, slot)?;
@@ -504,7 +506,9 @@ where
         }
 
         if let TypeMeta::Static { size, .. } = Self::TYPE_META {
-            let writer = &mut writer.as_trusted_for(size)?;
+            // SAFETY: `Self::TYPE_META` specifies a static size, which is `N * static_size_of(T)`.
+            // `N` writes of `T` will write `size` bytes, fully initializing the trusted window.
+            let writer = &mut unsafe { writer.as_trusted_for(size) }?;
             for item in value {
                 T::write(writer, item)?;
             }
@@ -883,11 +887,13 @@ macro_rules! impl_seq {
             #[inline]
             fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
                 if let (TypeMeta::Static { size: key_size, .. }, TypeMeta::Static { size: value_size, .. }) = ($key::TYPE_META, $value::TYPE_META) {
+                    let len = src.len();
                     #[allow(clippy::arithmetic_side_effects)]
-                    let writer = &mut writer.as_trusted_for(
-                        <BincodeLen>::write_bytes_needed(src.len())? + (key_size + value_size) * src.len()
-                    )?;
-                    <BincodeLen>::write(writer, src.len())?;
+                    let needed = <BincodeLen>::write_bytes_needed(len)? + (key_size + value_size) * len;
+                    // SAFETY: `$key::TYPE_META` and `$value::TYPE_META` specify static sizes, so `len` writes of `($key::Src, $value::Src)`
+                    // and `<BincodeLen>::write` will write `needed` bytes, fully initializing the trusted window.
+                    let writer = &mut unsafe { writer.as_trusted_for(needed) }?;
+                    <BincodeLen>::write(writer, len)?;
                     for (k, v) in src.iter() {
                         $key::write(writer, k)?;
                         $value::write(writer, v)?;
@@ -919,7 +925,9 @@ macro_rules! impl_seq {
 
                 let map = if let (TypeMeta::Static { size: key_size, .. }, TypeMeta::Static { size: value_size, .. }) = ($key::TYPE_META, $value::TYPE_META) {
                     #[allow(clippy::arithmetic_side_effects)]
-                    let reader = &mut reader.as_trusted_for((key_size + value_size) * len)?;
+                    // SAFETY: `$key::TYPE_META` and `$value::TYPE_META` specify static sizes, so `len` reads of `($key::Dst, $value::Dst)`
+                    // will consume `(key_size + value_size) * len` bytes, fully consuming the trusted window.
+                    let reader = &mut unsafe { reader.as_trusted_for((key_size + value_size) * len) }?;
                     (0..len)
                         .map(|_| {
                             let k = $key::get(reader)?;
@@ -977,7 +985,9 @@ macro_rules! impl_seq {
                 let map = match $key::TYPE_META {
                     TypeMeta::Static { size, .. } => {
                         #[allow(clippy::arithmetic_side_effects)]
-                        let reader = &mut reader.as_trusted_for(size * len)?;
+                        // SAFETY: `$key::TYPE_META` specifies a static size, so `len` reads of `T::Dst`
+                        // will consume `size * len` bytes, fully consuming the trusted window.
+                        let reader = &mut unsafe { reader.as_trusted_for(size * len) }?;
                         (0..len)
                             .map(|_| $key::get(reader))
                             .collect::<ReadResult<_>>()?

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -167,8 +167,11 @@ where
 {
     if let TypeMeta::Static { size, .. } = T::TYPE_META {
         #[allow(clippy::arithmetic_side_effects)]
-        let mut writer =
-            writer.as_trusted_for(Len::write_bytes_needed(src.len())? + size * src.len())?;
+        let needed = Len::write_bytes_needed(src.len())? + size * src.len();
+        // SAFETY: `needed` is the size of the encoded length plus the size of the items.
+        // `Len::write` and len writes of `T::Src` will write `needed` bytes,
+        // fully initializing the trusted window.
+        let mut writer = unsafe { writer.as_trusted_for(needed) }?;
         Len::write(&mut writer, src.len())?;
         for item in src {
             T::write(&mut writer, item)?;
@@ -195,7 +198,11 @@ where
     T::Src: Sized,
 {
     if type_equal::<T::Src, u8>() {
-        let writer = &mut writer.as_trusted_for(Len::write_bytes_needed(src.len())? + src.len())?;
+        let needed = Len::write_bytes_needed(src.len())? + src.len();
+        // SAFETY: `needed` is the size of the encoded length plus the size of the slice (bytes).
+        // `Len::write` and `writer.write(src)` will write `needed` bytes,
+        // fully initializing the trusted window.
+        let writer = &mut unsafe { writer.as_trusted_for(needed) }?;
         Len::write(writer, src.len())?;
         writer.write(unsafe { transmute::<&[T::Src], &[u8]>(src) })?;
         writer.finish()?;


### PR DESCRIPTION
### Background
The notion of "trusted" `Reader` and `Writer`s was introduced in #16.

In short, trusted `Reader` and `Writer`s are implementations of the `Reader` and `Writer` traits that can be used when a serializer / deserializer for a type determines that the type that it is encoding / decoding has a compile-time known serialized size. They can call `reader.as_trusted_for(n_bytes)` to specify "I assert that the next set of reads or writes performed on this `Reader` / `Writer` will read/write precisely `n_bytes`". This allows the `Reader` / `Writer` to elide bounds checks within that `n_bytes` window, which yields a significant performance improvement, especially on large datasets.

### This PR
Trusted `Reader` and `Writer` types must be public because they're referenced as associated types of the untrusted variants. E.g.,
https://github.com/anza-xyz/wincode/blob/1a79bc32aa39264e4d3f5fe7d381a183850d20dd/wincode/src/io/slice.rs#L156-L160

But, we should prevent them from being manually constructed given the potential for unsafe usage with safe APIs (e.g., we should prevent users calling `TrustedSliceReader::new()` manually). These trusted variants are always available via `as_trusted_for` on the corresponding untrusted variant, and they are safe to use if acquired with `as_trusted_for` and the safety contract is upheld (no reads or writes are attempted past the requested `n_bytes`).

Additionally in line with the above, `as_trusted_for` is now marked as `unsafe`. Even though `as_trusted_for` does an initial bounds check, there is nothing preventing the user from over reading / writing through safe APIs after the initial bounds check succeeds. Marking this function as `unsafe` forces the user to be aware of the safety invariants.