### PR TITLE
perf: declare fns as const in wincode

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -105,7 +105,7 @@ impl Field {
     ///
     /// If the field has a `with` attribute, return it.
     /// Otherwise, return the type.
-    pub(crate) fn target(&self) -> &Type {
+    pub(crate) const fn target(&self) -> &Type {
         if let Some(with) = &self.with {
             with
         } else {
@@ -447,7 +447,7 @@ impl StructRepr {
     /// Check if this `#[repr]` attribute is eligible for zero-copy deserialization.
     ///
     /// Zero-copy deserialization is only supported for `#[repr(transparent)]` and `#[repr(C)]` structs.
-    pub(crate) fn is_zero_copy_eligible(&self) -> bool {
+    pub(crate) const fn is_zero_copy_eligible(&self) -> bool {
         matches!(self.layout, Layout::Transparent | Layout::C)
     }
 }
@@ -492,7 +492,7 @@ pub(crate) fn extract_repr(input: &DeriveInput, trait_impl: TraitImpl) -> Result
 /// Visitor to recursively collect the generic arguments of a type.
 struct GenericStack<'ast>(VecDeque<&'ast Type>);
 impl<'ast> GenericStack<'ast> {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self(VecDeque::new())
     }
 }

--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -381,7 +381,7 @@ pub struct TrustedVecWriter<'a> {
 
 #[cfg(feature = "alloc")]
 impl<'a> TrustedVecWriter<'a> {
-    pub fn new(inner: &'a mut [MaybeUninit<u8>], pos: &'a mut usize) -> Self {
+    pub const fn new(inner: &'a mut [MaybeUninit<u8>], pos: &'a mut usize) -> Self {
         Self { inner, pos }
     }
 }

--- a/wincode/src/io/vec.rs
+++ b/wincode/src/io/vec.rs
@@ -15,7 +15,7 @@ pub struct TrustedVecWriter<'a> {
 }
 
 impl<'a> TrustedVecWriter<'a> {
-    pub fn new(inner: &'a mut Vec<u8>) -> Self {
+    pub const fn new(inner: &'a mut Vec<u8>) -> Self {
         Self { inner }
     }
 }

--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -442,7 +442,7 @@ pub(crate) struct SliceDropGuard<T> {
 }
 
 impl<T> SliceDropGuard<T> {
-    pub(crate) fn new(ptr: *mut MaybeUninit<T>) -> Self {
+    pub(crate) const fn new(ptr: *mut MaybeUninit<T>) -> Self {
         Self {
             ptr,
             initialized_len: 0,
@@ -451,7 +451,7 @@ impl<T> SliceDropGuard<T> {
 
     #[inline(always)]
     #[allow(clippy::arithmetic_side_effects)]
-    pub(crate) fn inc_len(&mut self) {
+    pub(crate) const fn inc_len(&mut self) {
         self.initialized_len += 1;
     }
 }
@@ -579,7 +579,7 @@ macro_rules! impl_heap_slice {
 
                 impl<T> DropGuard<T> {
                     #[inline(always)]
-                    fn new(fat: *mut [MaybeUninit<T>], raw: *mut MaybeUninit<T>) -> Self {
+                    const fn new(fat: *mut [MaybeUninit<T>], raw: *mut MaybeUninit<T>) -> Self {
                         Self {
                             inner: ManuallyDrop::new(SliceDropGuard::new(raw)),
                             // We need to store the fat pointer to deallocate the container.


### PR DESCRIPTION
#### Problem

`wincode` crate has a couple of candidates to be declared as `const fn` which brings a slightly better performance

#### Solution

declare those `fn`s as `const`

cc @cpubot 