### PR TITLE
Reduce keywords

### DIFF
--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 categories = ["encoding", "network-programming"]
-keywords = ["binary", "encode", "decode", "serialize", "deserialize", "bincode"]
+keywords = ["binary", "encode", "serialize", "deserialize", "bincode"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
Apparently crates.io only allows 5 keywords:
```
Caused by:
  the remote server responded with an error (status 400 Bad Request): expected at most 5 keywords per crate
```