### PR TITLE
Ensure HashMaps are preallocated in read

### DIFF
--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -1003,7 +1003,6 @@ macro_rules! impl_seq {
                     // SAFETY: `$key::TYPE_META` and `$value::TYPE_META` specify static sizes, so `len` reads of `($key::Dst, $value::Dst)`
                     // will consume `(key_size + value_size) * len` bytes, fully consuming the trusted window.
                     let reader = &mut unsafe { reader.as_trusted_for((key_size + value_size) * len) }?;
-                    #[allow(clippy::redundant_closure)]
                     let mut map = $with_capacity(len);
                     for _ in 0..len {
                         let k = $key::get(reader)?;
@@ -1012,7 +1011,6 @@ macro_rules! impl_seq {
                     }
                     map
                 } else {
-                    #[allow(clippy::redundant_closure)]
                     let mut map = $with_capacity(len);
                     for _ in 0..len {
                         let k = $key::get(reader)?;
@@ -1065,7 +1063,6 @@ macro_rules! impl_seq {
                         // SAFETY: `$key::TYPE_META` specifies a static size, so `len` reads of `T::Dst`
                         // will consume `size * len` bytes, fully consuming the trusted window.
                         let reader = &mut unsafe { reader.as_trusted_for(size * len) }?;
-                        #[allow(clippy::redundant_closure)]
                         let mut set = $with_capacity(len);
                         for _ in 0..len {
                             set.$insert($key::get(reader)?);
@@ -1073,7 +1070,6 @@ macro_rules! impl_seq {
                         set
                     }
                     TypeMeta::Dynamic => {
-                        #[allow(clippy::redundant_closure)]
                         let mut set = $with_capacity(len);
                         for _ in 0..len {
                             set.$insert($key::get(reader)?);
@@ -1090,9 +1086,9 @@ macro_rules! impl_seq {
 }
 
 impl_seq! { "alloc", BTreeMap<K: Ord, V>, |_| BTreeMap::new() }
-impl_seq! { "std", HashMap<K: Hash | Eq, V>, |len| HashMap::with_capacity(len) }
+impl_seq! { "std", HashMap<K: Hash | Eq, V>, HashMap::with_capacity }
 impl_seq! { "alloc", BTreeSet<K: Ord>, |_| BTreeSet::new(), insert }
-impl_seq! { "std", HashSet<K: Hash | Eq>, |len| HashSet::with_capacity(len), insert }
+impl_seq! { "std", HashSet<K: Hash | Eq>, HashSet::with_capacity, insert }
 impl_seq! { "alloc", LinkedList<K:>, |_| LinkedList::new(), push_back }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
`HashMap`s are currently not preallocated in deserialization, resulting in suboptimal performance.

The issue is subtle:
https://github.com/anza-xyz/wincode/blob/8499c0092428c5efb2e7e569d1e778079ad0e6a0/wincode/src/schema/impls.rs#L1006-L1012

Normally, the `FromIter` implementation of `HashMap` would preallocate capacity based on the source iterator's `size_hint`. The problem here is that we're actually collecting into a `Result<HashMap<_, _>, _>`, and `Result`'s `FromIterator` prevents this from happening.

This PR adjusts the implementation to avoid `Result`'s `FromIterator` and preallocates and inserts explicitly.

Results:
<img width="1113" height="196" alt="image" src="https://github.com/user-attachments/assets/f903df27-efa2-4b1c-a093-725b46eba06d" />

Performance of the other types used in the macro are unaffected, as they don't support preallocation.