### PR TITLE
schema: Implement `ZeroCopy` for all integer types

### DIFF
--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -58,6 +58,9 @@ macro_rules! impl_int {
 
             const TYPE_META: TypeMeta = TypeMeta::Static {
                 size: size_of::<$type>(),
+                #[cfg(target_endian = "little")]
+                zero_copy: true,
+                #[cfg(not(target_endian = "little"))]
                 zero_copy: $zero_copy,
             };
 
@@ -77,6 +80,9 @@ macro_rules! impl_int {
 
             const TYPE_META: TypeMeta = TypeMeta::Static {
                 size: size_of::<$type>(),
+                #[cfg(target_endian = "little")]
+                zero_copy: true,
+                #[cfg(not(target_endian = "little"))]
                 zero_copy: $zero_copy,
             };
 
@@ -152,6 +158,19 @@ unsafe impl ZeroCopy for u8 {}
 // SAFETY:
 // - i8 is similarly a canonical zero-copy type: no endianness, no layout, no validation.
 unsafe impl ZeroCopy for i8 {}
+
+macro_rules! impl_numeric_zero_copy {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            unsafe impl ZeroCopy for $ty {}
+        )+
+    };
+}
+
+// SAFETY: Primitive numeric types with fixed size. Only valid on little endian
+// platforms because Bincode specifies little endian integer encoding.
+#[cfg(target_endian = "little")]
+impl_numeric_zero_copy!(u16, i16, u32, i32, u64, i64, u128, i128, f32, f64);
 
 impl_int!(u8, zero_copy: true);
 impl_int!(i8, zero_copy: true);

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -252,6 +252,39 @@ mod tests {
         },
     };
 
+    #[cfg(target_endian = "little")]
+    #[derive(
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Ord,
+        PartialOrd,
+        SchemaWrite,
+        SchemaRead,
+        proptest_derive::Arbitrary,
+        Hash,
+    )]
+    #[wincode(internal)]
+    #[repr(C)]
+    struct StructZeroCopy {
+        a: u128,
+        b: i128,
+        c: u64,
+        d: i64,
+        e: u32,
+        f: i32,
+        ar1: [u8; 8],
+        g: u16,
+        h: i16,
+        ar2: [u8; 12],
+        i: u8,
+        j: i8,
+        ar3: [u8; 14],
+    }
+
+    #[cfg(not(target_endian = "little"))]
     #[derive(
         serde::Serialize,
         serde::Deserialize,
@@ -314,8 +347,24 @@ mod tests {
 
     #[test]
     fn struct_zero_copy_derive_size() {
+        #[cfg(target_endian = "little")]
+        let size = size_of::<u128>()
+            + size_of::<i128>()
+            + size_of::<u64>()
+            + size_of::<i64>()
+            + size_of::<u32>()
+            + size_of::<i32>()
+            + size_of::<[u8; 8]>()
+            + size_of::<u16>()
+            + size_of::<i16>()
+            + size_of::<[u8; 12]>()
+            + size_of::<u8>()
+            + size_of::<i8>()
+            + size_of::<[u8; 14]>();
+        #[cfg(not(target_endian = "little"))]
+        let size = size_of::<u8>() + size_of::<[u8; 32]>();
         let expected = TypeMeta::Static {
-            size: size_of::<u8>() + size_of::<[u8; 32]>(),
+            size,
             zero_copy: true,
         };
         assert_eq!(<StructZeroCopy as SchemaWrite>::TYPE_META, expected);


### PR DESCRIPTION
Given that all integer types provide `to_le_bytes` methods and can be transmuted, implement `ZeroCopy` for them. Test that a struct with all supported primitive types and explicit padding supports zero-copy.