### PR TITLE
Bump to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bincode",
  "criterion",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode-derive"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 description = "Derive macros for wincode"
 repository.workspace = true

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 description = "Fast bincode de/serialization with placement initialization"
 repository.workspace = true
@@ -46,4 +46,3 @@ quote.workspace = true
 name = "benchmarks"
 harness = false
 required-features = ["std", "derive"]
-


### PR DESCRIPTION
Diff: https://github.com/anza-xyz/wincode/compare/v0.2.2...v0.2.3

In summary:
- `ShortU16` now has `SchemaRead` and `SchemaWrite` impls so that they can be used directly as struct members (e.g., https://github.com/anza-xyz/agave/pull/7694)
- `struct_extensions` fix for mapped types and container types
- Comprehensive zero-copy support
- Some benchmark improvements