### PR TITLE
Bump to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bincode",
  "criterion",

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode"
-version = "0.2.3"
+version = "0.2.4"
 authors.workspace = true
 description = "Fast bincode de/serialization with placement initialization"
 repository.workspace = true


### PR DESCRIPTION

Adds mutable zero-copy deserialization support.
- https://github.com/anza-xyz/wincode/pull/58
- https://github.com/anza-xyz/wincode/pull/60