### PR TITLE
Add collection benchmarks for BTreeMap, BTreeSet, LinkedList, VecDeque

### DIFF
--- a/wincode/benches/benchmarks.rs
+++ b/wincode/benches/benchmarks.rs
@@ -997,7 +997,6 @@ criterion_group!(
     bench_btreeset_comparison,
     bench_linkedlist_comparison,
     bench_vecdeque_comparison,
-    bench_short_u16_comparison,
     bench_char_deserialization,
 );
 


### PR DESCRIPTION
Adds benchmarks for collections that were implemented but not benchmarked.

- BTreeMap<u64, u64>
- BTreeSet<u64>
- LinkedList<u64>
- VecDeque<u64>

Uses a macro to avoid code duplication (same pattern as enum benchmarks)
