### PR TITLE
Relax `SchemaRead::read` and `SchemaWrite::write` parameter types

### DIFF
--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -176,7 +176,7 @@ fn impl_struct(
 /// impl<'de> SchemaRead<'de> for Message {
 ///     type Dst = Message;
 ///
-///     fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+///     fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
 ///         // Some more complicated logic not capturable by the macro...
 ///         let mut body = MaybeUninit::<Body>::uninit();
 ///         // Project a mutable MaybeUninit<Header> from the MaybeUninit<Body>.
@@ -390,7 +390,7 @@ fn impl_struct_extensions(args: &SchemaArgs, crate_name: &Path) -> Result<TokenS
 
             /// Read a value from the reader into the maybe uninitialized field.
             #[inline]
-            #vis fn #read_field_ident <'de>(&mut self, reader: &mut impl Reader<'de>) -> ReadResult<&mut Self> {
+            #vis fn #read_field_ident <'de>(&mut self, reader: &mut (impl Reader<'de> + ?Sized)) -> ReadResult<&mut Self> {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
                 // - We return the field as `&mut MaybeUninit<#target>`, so
@@ -703,7 +703,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
                 const TYPE_META: TypeMeta = #type_meta_impl;
 
                 #[inline]
-                fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+                fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
                     #read_impl
                     Ok(())
                 }

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -265,7 +265,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
                 }
 
                 #[inline]
-                fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+                fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
                     #write_impl
                 }
             }

--- a/wincode/codegen/tuple.rs
+++ b/wincode/codegen/tuple.rs
@@ -125,7 +125,7 @@ pub fn generate(arity: usize, mut out: impl Write) -> Result<()> {
                 }
 
                 #[inline]
-                fn write(writer: &mut impl crate::io::Writer, value: &Self::Src) -> crate::WriteResult<()>
+                fn write(writer: &mut (impl crate::io::Writer + ?Sized), value: &Self::Src) -> crate::WriteResult<()>
                 {
                     use crate::io::Writer;
                     if let TypeMeta::Static { size, .. } = Self::TYPE_META {
@@ -154,7 +154,7 @@ pub fn generate(arity: usize, mut out: impl Write) -> Result<()> {
                 #[inline]
                 #[allow(clippy::arithmetic_side_effects, clippy::type_complexity)]
                 fn read(
-                    reader: &mut impl crate::io::Reader<'de>,
+                    reader: &mut (impl crate::io::Reader<'de> + ?Sized),
                     dst: &mut core::mem::MaybeUninit<Self::Dst>
                 ) -> crate::ReadResult<()>
                 {

--- a/wincode/src/config/serde.rs
+++ b/wincode/src/config/serde.rs
@@ -28,7 +28,7 @@ pub trait Serialize<C: Config>: SchemaWrite<C> {
     /// Serialize a serializable type into the given [`Writer`].
     #[inline]
     #[expect(unused_variables)]
-    fn serialize_into(dst: &mut impl Writer, src: &Self::Src, config: C) -> WriteResult<()> {
+    fn serialize_into(dst: &mut (impl Writer + ?Sized), src: &Self::Src, config: C) -> WriteResult<()> {
         Self::write(dst, src)?;
         dst.finish()?;
         Ok(())
@@ -72,7 +72,7 @@ pub trait DeserializeOwned<C: Config>: SchemaReadOwned<C> {
     /// Deserialize from the given [`Reader`] into a new `Self::Dst`.
     #[inline(always)]
     fn deserialize_from<'de>(
-        src: &mut impl Reader<'de>,
+        src: &mut (impl Reader<'de> + ?Sized),
     ) -> ReadResult<<Self as SchemaRead<'de, C>>::Dst> {
         Self::get(src)
     }
@@ -80,7 +80,7 @@ pub trait DeserializeOwned<C: Config>: SchemaReadOwned<C> {
     /// Deserialize from the given [`Reader`] into `dst`.
     #[inline]
     fn deserialize_from_into<'de>(
-        src: &mut impl Reader<'de>,
+        src: &mut (impl Reader<'de> + ?Sized),
         dst: &mut MaybeUninit<<Self as SchemaRead<'de, C>>::Dst>,
     ) -> ReadResult<()> {
         Self::read(src, dst)
@@ -112,7 +112,7 @@ where
 
 /// Like [`crate::serialize_into`], but allows the caller to provide a custom configuration.
 #[inline]
-pub fn serialize_into<T, C: Config>(dst: &mut impl Writer, src: &T, config: C) -> WriteResult<()>
+pub fn serialize_into<T, C: Config>(dst: &mut (impl Writer + ?Sized), src: &T, config: C) -> WriteResult<()>
 where
     T: SchemaWrite<C, Src = T> + ?Sized,
 {
@@ -164,7 +164,7 @@ where
 /// Like [`crate::deserialize_from`], but allows the caller to provide a custom configuration.
 #[inline(always)]
 #[expect(unused_variables)]
-pub fn deserialize_from<'de, T, C: Config>(src: &mut impl Reader<'de>, config: C) -> ReadResult<T>
+pub fn deserialize_from<'de, T, C: Config>(src: &mut (impl Reader<'de> + ?Sized), config: C) -> ReadResult<T>
 where
     T: SchemaReadOwned<C, Dst = T>,
 {

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -434,7 +434,7 @@
 //! impl<'de, C: Config> SchemaRead<'de, C> for Message {
 //!     type Dst = Message;
 //!
-//!     fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+//!     fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
 //!         // Normally we have to do a big ugly cast like this
 //!         // to get a mutable `MaybeUninit<Payload>`.
 //!         let payload = unsafe {

--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -228,7 +228,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         // SAFETY: `T` is plain ol' data.
         unsafe { Ok(writer.write_t(src)?) }
     }
@@ -245,7 +245,7 @@ where
         zero_copy: true,
     };
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         // SAFETY: `T` is plain ol' data.
         unsafe { Ok(reader.copy_into_t(dst)?) }
     }
@@ -270,7 +270,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         T::write(writer, src)
     }
 }
@@ -289,7 +289,7 @@ where
     const TYPE_META: TypeMeta = T::TYPE_META;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         T::read(reader, dst)
     }
 }
@@ -309,7 +309,7 @@ where
     }
 
     #[inline(always)]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         write_elem_slice::<T, Len, C>(writer, src)
     }
 }
@@ -322,7 +322,7 @@ where
 {
     type Dst = vec::Vec<T::Dst>;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let len = Len::read_prealloc_check::<T::Dst>(reader)?;
         let mut vec: vec::Vec<T::Dst> = vec::Vec::with_capacity(len);
 
@@ -423,7 +423,7 @@ macro_rules! impl_heap_slice {
             }
 
             #[inline(always)]
-            fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+            fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
                 write_elem_slice::<T, Len, C>(writer, src)
             }
         }
@@ -438,7 +438,7 @@ macro_rules! impl_heap_slice {
 
             #[inline(always)]
             fn read(
-                reader: &mut impl Reader<'de>,
+                reader: &mut (impl Reader<'de> + ?Sized),
                 dst: &mut MaybeUninit<Self::Dst>,
             ) -> ReadResult<()> {
                 /// Drop guard for `TypeMeta::Static { zero_copy: true }` types.
@@ -590,7 +590,7 @@ where
     }
 
     #[inline(always)]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         if let TypeMeta::Static {
             size,
             zero_copy: true,
@@ -631,7 +631,7 @@ where
     type Dst = collections::VecDeque<T::Dst>;
 
     #[inline(always)]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         // Leverage the contiguous read optimization of `Vec`.
         // From<Vec<T>> for VecDeque<T> is basically free.
         let vec = <Vec<T, Len>>::get(reader)?;
@@ -659,7 +659,7 @@ where
     }
 
     #[inline(always)]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         write_elem_slice::<T, Len, C>(writer, src.as_slice())
     }
 }
@@ -674,7 +674,7 @@ where
     type Dst = collections::BinaryHeap<T::Dst>;
 
     #[inline(always)]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let vec = <Vec<T, Len>>::get(reader)?;
         // Leverage the vec impl.
         dst.write(collections::BinaryHeap::from(vec));

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -59,7 +59,7 @@ macro_rules! impl_int {
             }
 
             #[inline(always)]
-            fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+            fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
                 Ok(writer.write(&src.to_le_bytes())?)
             }
         }
@@ -77,7 +77,7 @@ macro_rules! impl_int {
 
             #[inline(always)]
             fn read(
-                reader: &mut impl Reader<'de>,
+                reader: &mut (impl Reader<'de> + ?Sized),
                 dst: &mut MaybeUninit<Self::Dst>,
             ) -> ReadResult<()> {
                 // SAFETY: integer is plain ol' data.
@@ -106,7 +106,7 @@ macro_rules! impl_int {
             }
 
             #[inline]
-            fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+            fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
                 let src = *src as $cast;
                 // bincode defaults to little endian encoding.
                 // noop on LE machines.
@@ -124,7 +124,7 @@ macro_rules! impl_int {
 
             #[inline]
             fn read(
-                reader: &mut impl Reader<'de>,
+                reader: &mut (impl Reader<'de> + ?Sized),
                 dst: &mut MaybeUninit<Self::Dst>,
             ) -> ReadResult<()> {
                 let casted = <$cast as SchemaRead<'de, C>>::get(reader)?;
@@ -190,7 +190,7 @@ impl<C: ConfigCore> SchemaWrite<C> for bool {
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         unsafe { Ok(writer.write_t(&(*src as u8))?) }
     }
 }
@@ -204,7 +204,7 @@ impl<'de, C: ConfigCore> SchemaRead<'de, C> for bool {
     };
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         // SAFETY: u8 is plain ol' data.
         let byte = <u8 as SchemaRead<'de, C>>::get(reader)?;
         match byte {
@@ -231,7 +231,7 @@ impl<C: ConfigCore> SchemaWrite<C> for char {
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         let mut buf = [0; 4];
         let str = src.encode_utf8(&mut buf);
         writer.write(str.as_bytes())?;
@@ -243,7 +243,7 @@ impl<'de, C: ConfigCore> SchemaRead<'de, C> for char {
     type Dst = char;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let b0 = *reader.peek()?;
 
         let len = match b0 {
@@ -287,7 +287,7 @@ impl<T, C: ConfigCore> SchemaWrite<C> for PhantomData<T> {
     }
 
     #[inline]
-    fn write(_writer: &mut impl Writer, _src: &Self::Src) -> WriteResult<()> {
+    fn write(_writer: &mut (impl Writer + ?Sized), _src: &Self::Src) -> WriteResult<()> {
         Ok(())
     }
 }
@@ -301,7 +301,7 @@ impl<'de, T, C: ConfigCore> SchemaRead<'de, C> for PhantomData<T> {
     };
 
     #[inline]
-    fn read(_reader: &mut impl Reader<'de>, _dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(_reader: &mut (impl Reader<'de> + ?Sized), _dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         Ok(())
     }
 }
@@ -320,7 +320,7 @@ impl<C: ConfigCore> SchemaWrite<C> for () {
     }
 
     #[inline]
-    fn write(_writer: &mut impl Writer, _src: &Self::Src) -> WriteResult<()> {
+    fn write(_writer: &mut (impl Writer + ?Sized), _src: &Self::Src) -> WriteResult<()> {
         Ok(())
     }
 }
@@ -334,7 +334,7 @@ impl<'de, C: ConfigCore> SchemaRead<'de, C> for () {
     };
 
     #[inline]
-    fn read(_reader: &mut impl Reader<'de>, _dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(_reader: &mut (impl Reader<'de> + ?Sized), _dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         Ok(())
     }
 }
@@ -353,7 +353,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         <containers::Vec<T, C::LengthEncoding>>::write(writer, value)
     }
 }
@@ -366,7 +366,7 @@ where
     type Dst = Vec<T::Dst>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         <containers::Vec<T, C::LengthEncoding>>::read(reader, dst)
     }
 }
@@ -385,7 +385,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         <containers::VecDeque<T, C::LengthEncoding>>::write(writer, value)
     }
 }
@@ -398,7 +398,7 @@ where
     type Dst = VecDeque<T::Dst>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         <containers::VecDeque<T, C::LengthEncoding>>::read(reader, dst)
     }
 }
@@ -416,7 +416,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         write_elem_slice::<T, C::LengthEncoding, C>(writer, value)
     }
 }
@@ -443,7 +443,7 @@ where
     };
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         if let TypeMeta::Static {
             zero_copy: true, ..
         } = T::TYPE_META
@@ -510,7 +510,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         match Self::TYPE_META {
             TypeMeta::Static {
                 zero_copy: true, ..
@@ -548,7 +548,7 @@ where
     type Dst = Option<T::Dst>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let variant = <u8 as SchemaRead<'de, C>>::get(reader)?;
         match variant {
             0 => dst.write(Option::None),
@@ -578,7 +578,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         match value {
             Option::Some(value) => {
                 <u8 as SchemaWrite<C>>::write(writer, &1)?;
@@ -609,7 +609,7 @@ where
     };
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let variant = <u32 as SchemaRead<'de, C>>::get(reader)?;
         match variant {
             0 => dst.write(Result::Ok(T::get(reader)?)),
@@ -653,7 +653,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         match value {
             Result::Ok(value) => {
                 <u32 as SchemaWrite<C>>::write(writer, &0)?;
@@ -682,7 +682,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         T::write(writer, *value)
     }
 }
@@ -712,7 +712,7 @@ macro_rules! impl_heap_container {
             }
 
             #[inline]
-            fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+            fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
                 T::write(writer, value)
             }
         }
@@ -736,7 +736,7 @@ macro_rules! impl_heap_container {
 
             #[inline]
             fn read(
-                reader: &mut impl Reader<'de>,
+                reader: &mut (impl Reader<'de> + ?Sized),
                 dst: &mut MaybeUninit<Self::Dst>,
             ) -> ReadResult<()> {
                 struct DropGuard<T>(*mut MaybeUninit<T>);
@@ -782,7 +782,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         <containers::Box<[T], C::LengthEncoding>>::write(writer, value)
     }
 }
@@ -801,7 +801,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         <containers::Rc<[T], C::LengthEncoding>>::write(writer, value)
     }
 }
@@ -820,7 +820,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, value: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), value: &Self::Src) -> WriteResult<()> {
         <containers::Arc<[T], C::LengthEncoding>>::write(writer, value)
     }
 }
@@ -833,7 +833,7 @@ where
     type Dst = Box<[T::Dst]>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         <containers::Box<[T], C::LengthEncoding>>::read(reader, dst)
     }
 }
@@ -846,7 +846,7 @@ where
     type Dst = Rc<[T::Dst]>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         <containers::Rc<[T], C::LengthEncoding>>::read(reader, dst)
     }
 }
@@ -859,7 +859,7 @@ where
     type Dst = Arc<[T::Dst]>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         <containers::Arc<[T], C::LengthEncoding>>::read(reader, dst)
     }
 }
@@ -875,7 +875,7 @@ impl<C: Config> SchemaWrite<C> for str {
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         C::LengthEncoding::write(writer, src.len())?;
         writer.write(src.as_bytes())?;
         Ok(())
@@ -892,7 +892,7 @@ impl<C: Config> SchemaWrite<C> for String {
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         <str as SchemaWrite<C>>::write(writer, src)
     }
 }
@@ -901,7 +901,7 @@ impl<'de, C: Config> SchemaRead<'de, C> for &'de str {
     type Dst = &'de str;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let len = C::LengthEncoding::read(reader)?;
         let bytes = reader.borrow_exact(len)?;
         match core::str::from_utf8(bytes) {
@@ -919,7 +919,7 @@ impl<'de, C: Config> SchemaRead<'de, C> for String {
     type Dst = String;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let len = C::LengthEncoding::read_prealloc_check::<u8>(reader)?;
         let bytes = reader.fill_exact(len)?.to_vec();
         unsafe { reader.consume_unchecked(len) };
@@ -972,7 +972,7 @@ macro_rules! impl_seq {
             }
 
             #[inline]
-            fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+            fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
                 if let (TypeMeta::Static { size: key_size, .. }, TypeMeta::Static { size: value_size, .. }) = ($key::TYPE_META, $value::TYPE_META) {
                     let len = src.len();
                     #[allow(clippy::arithmetic_side_effects)]
@@ -1007,7 +1007,7 @@ macro_rules! impl_seq {
             type Dst = $target<$key::Dst, $value::Dst>;
 
             #[inline]
-            fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
                 let len = C::LengthEncoding::read_prealloc_check::<($key::Dst, $value::Dst)>(reader)?;
 
                 let map = if let (TypeMeta::Static { size: key_size, .. }, TypeMeta::Static { size: value_size, .. }) = ($key::TYPE_META, $value::TYPE_META) {
@@ -1052,7 +1052,7 @@ macro_rules! impl_seq {
             }
 
             #[inline]
-            fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+            fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
                 write_elem_iter::<$key, C::LengthEncoding, C>(writer, src.iter())
             }
         }
@@ -1066,7 +1066,7 @@ macro_rules! impl_seq {
             type Dst = $target<$key::Dst>;
 
             #[inline]
-            fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
                 let len = C::LengthEncoding::read_prealloc_check::<$key::Dst>(reader)?;
 
                 let map = match $key::TYPE_META {
@@ -1117,7 +1117,7 @@ where
     }
 
     #[inline]
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(writer: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         <containers::BinaryHeap<T, C::LengthEncoding>>::write(writer, src)
     }
 }
@@ -1131,7 +1131,7 @@ where
     type Dst = BinaryHeap<T::Dst>;
 
     #[inline]
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         <containers::BinaryHeap<T, C::LengthEncoding>>::read(reader, dst)
     }
 }
@@ -1324,7 +1324,7 @@ mod zero_copy {
     /// multiplied by the size of the element type.
     #[inline(always)]
     pub(super) fn read_slice_len_checked<'de, C: Config>(
-        reader: &mut impl Reader<'de>,
+        reader: &mut (impl Reader<'de> + ?Sized),
         size: usize,
     ) -> ReadResult<(usize, usize)> {
         let len = C::LengthEncoding::read(reader)?;
@@ -1343,7 +1343,7 @@ where
 
     const TYPE_META: TypeMeta = zero_copy::type_meta_t::<T, C>();
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let size = T::TYPE_META.size_assert_zero_copy();
         let bytes = reader.borrow_exact(size)?;
         // SAFETY:
@@ -1363,7 +1363,7 @@ where
 
     const TYPE_META: TypeMeta = zero_copy::type_meta_t::<T, C>();
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let size = T::TYPE_META.size_assert_zero_copy();
         let bytes = reader.borrow_exact_mut(size)?;
         // SAFETY:
@@ -1383,7 +1383,7 @@ where
 
     const TYPE_META: TypeMeta = zero_copy::type_meta_slice::<T, C>();
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let size = T::TYPE_META.size_assert_zero_copy();
         let (len, total_size) = zero_copy::read_slice_len_checked::<C>(reader, size)?;
         let bytes = reader.borrow_exact(total_size)?;
@@ -1404,7 +1404,7 @@ where
 
     const TYPE_META: TypeMeta = zero_copy::type_meta_slice::<T, C>();
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(reader: &mut (impl Reader<'de> + ?Sized), dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let size = T::TYPE_META.size_assert_zero_copy();
         let (len, total_size) = zero_copy::read_slice_len_checked::<C>(reader, size)?;
         let bytes = reader.borrow_exact_mut(total_size)?;

--- a/wincode/src/serde.rs
+++ b/wincode/src/serde.rs
@@ -58,7 +58,7 @@ pub trait DeserializeOwned: SchemaReadOwned<DefaultConfig> {
     /// Deserialize from the given [`Reader`] into a new `Self::Dst`.
     #[inline(always)]
     fn deserialize_from<'de>(
-        src: &mut impl Reader<'de>,
+        src: &mut (impl Reader<'de> + ?Sized),
     ) -> ReadResult<<Self as SchemaRead<'de, DefaultConfig>>::Dst> {
         Self::get(src)
     }
@@ -66,7 +66,7 @@ pub trait DeserializeOwned: SchemaReadOwned<DefaultConfig> {
     /// Deserialize from the given [`Reader`] into `dst`.
     #[inline]
     fn deserialize_from_into<'de>(
-        src: &mut impl Reader<'de>,
+        src: &mut (impl Reader<'de> + ?Sized),
         dst: &mut MaybeUninit<<Self as SchemaRead<'de, DefaultConfig>>::Dst>,
     ) -> ReadResult<()> {
         Self::read(src, dst)
@@ -111,7 +111,7 @@ pub trait Serialize: SchemaWrite<DefaultConfig> {
 
     /// Serialize a serializable type into the given byte buffer.
     #[inline]
-    fn serialize_into(dst: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn serialize_into(dst: &mut (impl Writer + ?Sized), src: &Self::Src) -> WriteResult<()> {
         <Self as config::Serialize<DefaultConfig>>::serialize_into(
             dst,
             src,
@@ -230,7 +230,7 @@ where
 /// requires [`SchemaReadOwned`] instead of [`SchemaRead`]. If you are deserializing
 /// from raw bytes, always prefer [`deserialize`] for maximum flexibility.
 #[inline(always)]
-pub fn deserialize_from<'de, T>(src: &mut impl Reader<'de>) -> ReadResult<T>
+pub fn deserialize_from<'de, T>(src: &mut (impl Reader<'de> + ?Sized)) -> ReadResult<T>
 where
     T: SchemaReadOwned<DefaultConfig, Dst = T>,
 {
@@ -267,7 +267,7 @@ where
 ///
 /// Like [`serialize`], but allows the caller to provide their own writer.
 #[inline]
-pub fn serialize_into<T>(dst: &mut impl Writer, src: &T) -> WriteResult<()>
+pub fn serialize_into<T>(dst: &mut (impl Writer + ?Sized), src: &T) -> WriteResult<()>
 where
     T: SchemaWrite<DefaultConfig, Src = T> + ?Sized,
 {


### PR DESCRIPTION
There's no reason to require a "`Sized`" implementor, i.e. one that could be moved to the stack.

This restriction has maybe hidden the issue fixed in #87, as the `Writer` implementation could not be tested.