### PR TITLE
Implement varint encoding

### DIFF
--- a/wincode/src/config/mod.rs
+++ b/wincode/src/config/mod.rs
@@ -8,7 +8,7 @@
 //! additional configuration parameter.
 use {
     crate::{
-        int_encoding::{BigEndian, ByteOrder, FixInt, IntEncoding, LittleEndian},
+        int_encoding::{BigEndian, ByteOrder, FixInt, IntEncoding, LittleEndian, VarInt},
         len::{BincodeLen, SeqLen},
     },
     core::marker::PhantomData,
@@ -221,6 +221,27 @@ impl<
         LengthEncoding,
         ByteOrder,
         FixInt,
+    > {
+        generate()
+    }
+
+    /// Use [`VarInt`] for integer encoding.
+    ///
+    /// Default is [`FixInt`].
+    ///
+    /// Performance note: variable length integer encoding will hurt serialization and deserialization
+    /// performance significantly relative to fixed width integer encoding. Additionally, all zero-copy
+    /// capabilities on integers will be lost. Variable length integer encoding may be beneficial if
+    /// reducing the resulting size of serialized data is important, but if serialization / deserialization
+    /// performance is important, fixed width integer encoding is highly recommended.
+    pub const fn with_varint_encoding(
+        self,
+    ) -> Configuration<
+        ZERO_COPY_ALIGN_CHECK,
+        PREALLOCATION_SIZE_LIMIT,
+        LengthEncoding,
+        ByteOrder,
+        VarInt,
     > {
         generate()
     }

--- a/wincode/src/io/mod.rs
+++ b/wincode/src/io/mod.rs
@@ -24,7 +24,7 @@ pub enum ReadError {
 pub type ReadResult<T> = core::result::Result<T, ReadError>;
 
 #[cold]
-const fn read_size_limit(len: usize) -> ReadError {
+pub const fn read_size_limit(len: usize) -> ReadError {
     ReadError::ReadSizeLimit(len)
 }
 

--- a/wincode/src/schema/int_encoding.rs
+++ b/wincode/src/schema/int_encoding.rs
@@ -5,7 +5,8 @@
 use {
     crate::{
         config::{ConfigCore, ZeroCopy},
-        io::{Reader, Writer},
+        error::invalid_tag_encoding,
+        io::{read_size_limit, Reader, Writer},
         ReadResult, WriteResult,
     },
     paste::paste,
@@ -279,3 +280,368 @@ unsafe impl IntEncoding<LittleEndian> for FixInt {
 /// implementation delegates its integer encoding to the configuration's
 /// [`IntEncoding`], it can constrain its [`ZeroCopy`] bound by that encoding.
 unsafe impl<C: ConfigCore> ZeroCopy<C> for FixInt where C::ByteOrder: PlatformEndian {}
+
+/// Variable length integer encoding.
+///
+/// Performance note: variable length integer encoding will hurt serialization and deserialization
+/// performance significantly relative to fixed width integer encoding. Additionally, all zero-copy
+/// capabilities on integers will be lost. Variable length integer encoding may be beneficial if
+/// reducing the resulting size of serialized data is important, but if serialization / deserialization
+/// performance is important, fixed width integer encoding is highly recommended.
+///
+/// Encoding an unsigned integer v (of any type excepting u8) works as follows:
+///
+/// 1. If `u < 251`, encode it as a single byte with that value.
+/// 2. If `251 <= u < 2**16`, encode it as a literal byte 251, followed by a u16 with value `u`.
+/// 3. If `2**16 <= u < 2**32`, encode it as a literal byte 252, followed by a u32 with value `u`.
+/// 4. If `2**32 <= u < 2**64`, encode it as a literal byte 253, followed by a u64 with value `u`.
+/// 5. If `2**64 <= u < 2**128`, encode it as a literal byte 254, followed by a u128 with value `u`.
+///
+/// Then, for signed integers, we first convert to unsigned using the zigzag algorithm,
+/// and then encode them as we do for unsigned integers generally. The reason we use this
+/// algorithm is that it encodes those values which are close to zero in less bytes; the
+/// obvious algorithm, where we encode the cast values, gives a very large encoding for all
+/// negative values.
+///
+/// The zigzag algorithm is defined as follows:
+///
+/// ```
+/// # type Signed = i32;
+/// # type Unsigned = u32;
+/// fn zigzag(v: Signed) -> Unsigned {
+///     match v {
+///         0 => 0,
+///         // To avoid the edge case of Signed::min_value()
+///         // !n is equal to `-n - 1`, so this is:
+///         // !n * 2 + 1 = 2(-n - 1) + 1 = -2n - 2 + 1 = -2n - 1
+///         v if v < 0 => !(v as Unsigned) * 2 + 1,
+///         v if v > 0 => (v as Unsigned) * 2,
+/// #       _ => unreachable!()
+///     }
+/// }
+/// ```
+///
+/// And works such that:
+///
+/// ```
+/// # let zigzag = |n: i64| -> u64 {
+/// #     match n {
+/// #         0 => 0,
+/// #         v if v < 0 => !(v as u64) * 2 + 1,
+/// #         v if v > 0 => (v as u64) * 2,
+/// #         _ => unreachable!(),
+/// #     }
+/// # };
+/// assert_eq!(zigzag(0), 0);
+/// assert_eq!(zigzag(-1), 1);
+/// assert_eq!(zigzag(1), 2);
+/// assert_eq!(zigzag(-2), 3);
+/// assert_eq!(zigzag(2), 4);
+/// // etc
+/// assert_eq!(zigzag(i64::min_value()), u64::max_value());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VarInt;
+
+impl VarInt {
+    /// Returns the byte discriminant and subsequent byte slice needed to read the value.
+    ///
+    /// Soft requests (i.e., can return fewer) `size_of::<T>() + 1` bytes with `fill_buf`.
+    #[inline]
+    fn get_discriminant_and_bytes<'de, T>(
+        reader: &mut impl Reader<'de>,
+    ) -> ReadResult<(u8, &[u8])> {
+        // Fill the buffer with enough bytes to read the discriminant and the value.
+        //
+        // `fill_buf` returns _up to_ the given number of bytes, so will return fewer at EOF,
+        // and wont error if it returns fewer than requested.
+        #[expect(clippy::arithmetic_side_effects)]
+        let bytes = reader.fill_buf(size_of::<T>() + 1)?;
+        let Some((discriminant, bytes)) = bytes.split_at_checked(1) else {
+            return Err(read_size_limit(1).into());
+        };
+        Ok((discriminant[0], bytes))
+    }
+}
+
+/// Attempt to convert the given byte slice into the target type using configured endianess.
+///
+/// Errors if the byte slice does not contain enough bytes.
+macro_rules! try_from_endian_bytes {
+    ($bytes:ident => $ty:ty as $target:ty) => {{
+        #[expect(clippy::arithmetic_side_effects)]
+        let needed = size_of::<$ty>() + 1;
+        let Some(bytes) = $bytes.get(..size_of::<$ty>()) else {
+            return Err(read_size_limit(needed).into());
+        };
+        let Ok(ar) = bytes.try_into() else {
+            return Err(read_size_limit(needed).into());
+        };
+        let val = match B::ENDIAN {
+            Endian::Big => <$ty>::from_be_bytes(ar),
+            Endian::Little => <$ty>::from_le_bytes(ar),
+        };
+        (val as $target, needed)
+    }};
+    ($bytes:ident => $ty:ty) => {{
+        try_from_endian_bytes!($bytes => $ty as $ty)
+    }};
+}
+
+/// Decode zigzag-encoded signed integers using the underlying unsigned VarInt decoder.
+macro_rules! varint_decode_signed {
+    ($ty:ty => $target:ty) => {
+        paste! {
+            #[inline]
+            fn [<decode_ $ty>]<'de>(reader: &mut impl Reader<'de>) -> ReadResult<$ty> {
+                let n = <VarInt as IntEncoding<B>>::[<decode_ $target>](reader)?;
+                Ok(if n % 2 == 0 {
+                    // positive number
+                    (n / 2) as _
+                } else {
+                    // negative number
+                    // !m * 2 + 1 = n
+                    // !m * 2 = n - 1
+                    // !m = (n - 1) / 2
+                    // m = !((n - 1) / 2)
+                    // since we have n is odd, we have floor(n / 2) = floor((n - 1) / 2)
+                    !(n / 2) as _
+                })
+            }
+        }
+    };
+}
+
+/// Return the encoded length of zigzag-encoded signed integers.
+macro_rules! varint_size_of_signed {
+    ($ty:ty => $target:ty) => {
+        paste! {
+            #[inline]
+            #[expect(clippy::arithmetic_side_effects)]
+            fn [<size_of_ $ty>](val: $ty) -> usize {
+                let n: $target = if val < 0 {
+                    (!(val as $target)) * 2 + 1
+                } else {
+                    (val as $target) * 2
+                };
+                <VarInt as IntEncoding<B>>::[<size_of_ $target>](n)
+            }
+        }
+    };
+}
+
+/// Encode signed integers by zigzag-mapping to the corresponding unsigned [`VarInt`] encoder.
+macro_rules! varint_encode_signed {
+    ($ty:ty => $target:ty) => {
+        paste! {
+            #[inline]
+            #[expect(clippy::arithmetic_side_effects)]
+            fn [<encode_ $ty>](val: $ty, writer: &mut impl Writer) -> WriteResult<()> {
+                let n: $target = if val < 0 {
+                    (!(val as $target)) * 2 + 1
+                } else {
+                    (val as $target) * 2
+                };
+                <VarInt as IntEncoding<B>>::[<encode_ $target>](n, writer)
+            }
+        }
+    };
+}
+
+/// Emit tag+payload for unsigned values based on the first matching cast width.
+macro_rules! varint_encode_unsigned_impl {
+    ($val:ident, $writer:ident, $ty:ty, $tag:ident => $cast:ty) => {{
+        let needed = size_of::<$cast>() + 1;
+        // SAFETY: tag (1 byte) + payload (`size_of::<$cast>()`) fully initialize the trusted
+        // window, so all writes stay within `needed` bytes.
+        let writer = &mut unsafe { $writer.as_trusted_for(needed) }?;
+        writer.write(&[$tag])?;
+        let encoded = $val as $cast;
+        let bytes = match B::ENDIAN {
+            Endian::Big => encoded.to_be_bytes(),
+            Endian::Little => encoded.to_le_bytes(),
+        };
+        writer.write(&bytes)?;
+        writer.finish()?;
+        Ok(())
+    }};
+    ($val:ident, $writer:ident, $ty:ty, $tag:ident => $cast:ty, $($rest_tag:ident => $rest_cast:ty),+ $(,)?) => {{
+        if $val <= <$cast>::MAX as $ty {
+            let needed = size_of::<$cast>() + 1;
+            // SAFETY: tag (1 byte) + payload (`size_of::<$cast>()`) fully initialize the trusted
+            // window, so all writes stay within `needed` bytes.
+            let writer = &mut unsafe { $writer.as_trusted_for(needed) }?;
+            writer.write(&[$tag])?;
+            let encoded = $val as $cast;
+            let bytes = match B::ENDIAN {
+                Endian::Big => encoded.to_be_bytes(),
+                Endian::Little => encoded.to_le_bytes(),
+            };
+            writer.write(&bytes)?;
+            writer.finish()?;
+            Ok(())
+        } else {
+            varint_encode_unsigned_impl!($val, $writer, $ty, $($rest_tag => $rest_cast),+)
+        }
+    }};
+}
+
+/// Generate `encode_*` functions for unsigned VarInt encodings using a tag->cast list.
+macro_rules! varint_encode_unsigned {
+    ($ty:ty, $($tag:ident => $cast:ty),+ $(,)?) => {
+        paste! {
+            #[inline]
+            #[expect(clippy::arithmetic_side_effects)]
+            fn [<encode_ $ty>](val: $ty, writer: &mut impl Writer) -> WriteResult<()> {
+                if val <= SINGLE_BYTE_MAX as $ty {
+                    writer.write(&[val as u8])?;
+                    return Ok(());
+                }
+                varint_encode_unsigned_impl!(val, writer, $ty, $($tag => $cast),+)
+            }
+        }
+    };
+}
+
+const SINGLE_BYTE_MAX: u8 = 250;
+const U16_BYTE: u8 = 251;
+const U32_BYTE: u8 = 252;
+const U64_BYTE: u8 = 253;
+const U128_BYTE: u8 = 254;
+
+unsafe impl<B: ByteOrder> IntEncoding<B> for VarInt {
+    const STATIC: bool = false;
+
+    const ZERO_COPY: bool = false;
+
+    #[inline]
+    fn size_of_u16(val: u16) -> usize {
+        if val <= SINGLE_BYTE_MAX as u16 {
+            1
+        } else {
+            3
+        }
+    }
+
+    fn decode_u16<'de>(reader: &mut impl Reader<'de>) -> ReadResult<u16> {
+        let (discriminant, bytes) = VarInt::get_discriminant_and_bytes::<u16>(reader)?;
+        let (out, used) = match discriminant {
+            byte @ 0..=SINGLE_BYTE_MAX => (byte as u16, 1),
+            U16_BYTE => try_from_endian_bytes!(bytes => u16),
+            byte => return Err(invalid_tag_encoding(byte as usize)),
+        };
+        // SAFETY: `used` represents the full number of bytes consumed.
+        unsafe { reader.consume_unchecked(used) };
+        Ok(out)
+    }
+
+    varint_encode_unsigned!(u16, U16_BYTE => u16);
+
+    #[inline]
+    fn size_of_u32(val: u32) -> usize {
+        if val <= SINGLE_BYTE_MAX as u32 {
+            1
+        } else if val <= u16::MAX as u32 {
+            3
+        } else {
+            5
+        }
+    }
+
+    fn decode_u32<'de>(reader: &mut impl Reader<'de>) -> ReadResult<u32> {
+        let (discriminant, bytes) = VarInt::get_discriminant_and_bytes::<u32>(reader)?;
+        let (out, used) = match discriminant {
+            byte @ 0..=SINGLE_BYTE_MAX => (byte as u32, 1),
+            U16_BYTE => try_from_endian_bytes!(bytes => u16 as u32),
+            U32_BYTE => try_from_endian_bytes!(bytes => u32),
+            byte => return Err(invalid_tag_encoding(byte as usize)),
+        };
+        // SAFETY: `used` represents the full number of bytes consumed.
+        unsafe { reader.consume_unchecked(used) };
+        Ok(out)
+    }
+
+    varint_encode_unsigned!(u32, U16_BYTE => u16, U32_BYTE => u32);
+
+    #[inline]
+    fn size_of_u64(val: u64) -> usize {
+        if val <= SINGLE_BYTE_MAX as u64 {
+            1
+        } else if val <= u16::MAX as u64 {
+            3
+        } else if val <= u32::MAX as u64 {
+            5
+        } else {
+            9
+        }
+    }
+
+    fn decode_u64<'de>(reader: &mut impl Reader<'de>) -> ReadResult<u64> {
+        let (discriminant, bytes) = VarInt::get_discriminant_and_bytes::<u64>(reader)?;
+        let (out, used) = match discriminant {
+            byte @ 0..=SINGLE_BYTE_MAX => (byte as u64, 1),
+            U16_BYTE => try_from_endian_bytes!(bytes => u16 as u64),
+            U32_BYTE => try_from_endian_bytes!(bytes => u32 as u64),
+            U64_BYTE => try_from_endian_bytes!(bytes => u64),
+            byte => return Err(invalid_tag_encoding(byte as usize)),
+        };
+        // SAFETY: `used` represents the full number of bytes consumed.
+        unsafe { reader.consume_unchecked(used) };
+        Ok(out)
+    }
+
+    varint_encode_unsigned!(u64, U16_BYTE => u16, U32_BYTE => u32, U64_BYTE => u64);
+
+    #[inline]
+    fn size_of_u128(val: u128) -> usize {
+        if val <= SINGLE_BYTE_MAX as u128 {
+            1
+        } else if val <= u16::MAX as u128 {
+            3
+        } else if val <= u32::MAX as u128 {
+            5
+        } else if val <= u64::MAX as u128 {
+            9
+        } else {
+            17
+        }
+    }
+
+    fn decode_u128<'de>(reader: &mut impl Reader<'de>) -> ReadResult<u128> {
+        let (discriminant, bytes) = VarInt::get_discriminant_and_bytes::<u128>(reader)?;
+        let (out, used) = match discriminant {
+            byte @ 0..=SINGLE_BYTE_MAX => (byte as u128, 1),
+            U16_BYTE => try_from_endian_bytes!(bytes => u16 as u128),
+            U32_BYTE => try_from_endian_bytes!(bytes => u32 as u128),
+            U64_BYTE => try_from_endian_bytes!(bytes => u64 as u128),
+            U128_BYTE => try_from_endian_bytes!(bytes => u128),
+            byte => return Err(invalid_tag_encoding(byte as usize)),
+        };
+        // SAFETY: `used` represents the full number of bytes consumed.
+        unsafe { reader.consume_unchecked(used) };
+        Ok(out)
+    }
+
+    varint_encode_unsigned!(
+        u128,
+        U16_BYTE => u16,
+        U32_BYTE => u32,
+        U64_BYTE => u64,
+        U128_BYTE => u128,
+    );
+
+    varint_size_of_signed!(i16 => u16);
+    varint_size_of_signed!(i32 => u32);
+    varint_size_of_signed!(i64 => u64);
+    varint_size_of_signed!(i128 => u128);
+
+    varint_encode_signed!(i16 => u16);
+    varint_encode_signed!(i32 => u32);
+    varint_encode_signed!(i64 => u64);
+    varint_encode_signed!(i128 => u128);
+
+    varint_decode_signed!(i16 => u16);
+    varint_decode_signed!(i32 => u32);
+    varint_decode_signed!(i64 => u64);
+    varint_decode_signed!(i128 => u128);
+}


### PR DESCRIPTION
Implements a new `IntEncoding`, `VarInt`, which is bit-for-bit compatible with bincode's varint encoding. Includes property tests asserting equivalence with bincode's implementation, and additional tests for boundary conditions.

Closes #59 