### PR TITLE
derive: Remove `const` from generated function

### DIFF
--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -381,8 +381,9 @@ fn impl_struct_extensions(args: &SchemaArgs, crate_name: &Path) -> Result<TokenS
             }
 
             /// Write a value to the maybe uninitialized field.
+            // This method can be marked `const` in the future when MSRV is >= 1.85.
             #[inline]
-            #vis const fn #write_uninit_field_ident(&mut self, val: #field_projection_type) -> &mut Self {
+            #vis fn #write_uninit_field_ident(&mut self, val: #field_projection_type) -> &mut Self {
                 self.#uninit_mut_ident().write(val);
                 #set_index_bit
                 self


### PR DESCRIPTION
### Problem

Since wincode is going to be use on on-chain programs, we should ideally set a MSRV that corresponds to a version bundled with platform-tools.

platform-tools `v1.51` bundles Rust `1.84.1` and this version seems a good compromise. The only issue is that `"const_maybe_uninit_write"` is only stable on `1.85` and it is used in one of the generated functions from the `SchemaRead` derive.

### Solution

Remove the `const` marker from the generated function. 

Note: setting the MSRV version will be done in a follow-up PR.