### PR TITLE
Migrate from `paste` to `pastey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,10 +432,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "plotters"
@@ -968,7 +968,7 @@ version = "0.3.0"
 dependencies = [
  "bincode",
  "criterion",
- "paste",
+ "pastey",
  "proc-macro2",
  "proptest",
  "proptest-derive",

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -27,7 +27,7 @@ uuid = ["dep:uuid"]
 uuid-serde-compat = ["uuid"]
 
 [dependencies]
-paste = "1.0.15"
+pastey = "0.2.1"
 solana-short-vec = { version = "3.0.0", optional = true }
 thiserror = { version = "2.0.16", default-features = false }
 wincode-derive = { version = "0.3.0", optional = true }

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -27,7 +27,7 @@ use {
         net::{IpAddr, Ipv4Addr, Ipv6Addr},
         time::Duration,
     },
-    paste::paste,
+    pastey::paste,
 };
 #[cfg(feature = "alloc")]
 use {

--- a/wincode/src/schema/int_encoding.rs
+++ b/wincode/src/schema/int_encoding.rs
@@ -9,7 +9,7 @@ use {
         io::{read_size_limit, Reader, Writer},
         ReadResult, WriteResult,
     },
-    paste::paste,
+    pastey::paste,
 };
 
 /// Byte order trait.


### PR DESCRIPTION
`paste` is no longer maintained. [`pastey`](https://crates.io/crates/pastey) is a maintained fork.

https://rustsec.org/advisories/RUSTSEC-2024-0436

Closes #116 