### PR TITLE
derive: Add rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/anza-xyz/wincode"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.84.1"
 
 [workspace.dependencies]
 quote = "1.0.41"

--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
### Problem

Following #111, we now need to set a MSRV `rust-version` on each package. Since `wincode` crate is referencing a published version of `wincode-derive`, we need to first update the `wincode-derive` crate.

### Solution

In this first PR we set the `rust-version` on the workspace and use it only on `wincode-derive`.