### PR TITLE
derive: Version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,17 +978,7 @@ dependencies = [
  "solana-short-vec",
  "thiserror",
  "uuid",
- "wincode-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wincode-derive"
-version = "0.3.0"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "wincode-derive 0.3.0",
 ]
 
 [[package]]
@@ -1004,6 +994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wincode-derive"
+version = "0.3.1"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wincode-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -1011,7 +1011,7 @@ dependencies = [
  "libfuzzer-sys",
  "serde",
  "wincode",
- "wincode-derive 0.3.0",
+ "wincode-derive 0.3.1",
 ]
 
 [[package]]

--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode-derive"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 description = "Derive macros for wincode"
 repository.workspace = true


### PR DESCRIPTION
### Problem

We need to bump `wincode-derive` version to publish the changes from #119.

### Solution

Bump `wincode-derive` version.