### PR TITLE
Adding path to dependency for CI testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,24 +935,12 @@ dependencies = [
  "solana-short-vec",
  "thiserror",
  "uuid",
- "wincode-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wincode-derive",
 ]
 
 [[package]]
 name = "wincode-derive"
 version = "0.3.1"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "wincode-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89833c7743abd1a831b7eb0fdfd7210bd8bedc297435e9426aad9b63d7c7f77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -968,7 +956,7 @@ dependencies = [
  "libfuzzer-sys",
  "serde",
  "wincode",
- "wincode-derive 0.3.1",
+ "wincode-derive",
 ]
 
 [[package]]

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -31,7 +31,7 @@ uuid-serde-compat = ["uuid"]
 pastey = "0.2.1"
 solana-short-vec = { version = "3.0.0", optional = true }
 thiserror = { version = "2.0.16", default-features = false }
-wincode-derive = { version = "0.3.1", optional = true }
+wincode-derive = { version = "0.3.1", path = "../wincode-derive", optional = true }
 uuid = { version = "1.20.0", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Specifying both registry and local version, so that when the published registry is used, and for CI and local testing, the path is used. 


See here for how it works https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations