### PR TITLE
ci: add quick link for release ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Summary
         run: |
           echo "Tag: ${TAG}" >> "${GITHUB_STEP_SUMMARY}"
-          echo "Ref: ${REF}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Ref: ${REF} (https://github.com/${{ github.repository }}/commit/${REF})" >> "${GITHUB_STEP_SUMMARY}"
         env:
           TAG: ${{ steps.meta.outputs.tag }}
           REF: ${{ steps.meta.outputs.ref }}


### PR DESCRIPTION
#### Problem

we generate this summary info when do a release: 

<img width="605" height="186" alt="Screenshot 2026-02-02 at 11 06 48" src="https://github.com/user-attachments/assets/5d4ceec5-f91d-4444-b894-972c95f79e3b" />

however, it's annoying that I have to copy and paste the ref to check it.

#### Summary of Changes

add a quick link to a release ref