### PR TITLE
add extra check in assert_zero_copy

### DIFF
--- a/wincode-derive/src/assert_zero_copy.rs
+++ b/wincode-derive/src/assert_zero_copy.rs
@@ -59,6 +59,12 @@ pub(crate) fn assert_zero_copy(args: &SchemaArgs, repr: &StructRepr) -> Result<T
                 assert_schema_read_impl::<#ident>()
             };
 
+            // Assert the struct itself implements `ZeroCopy`.
+            const _assert_struct_zerocopy_impl: fn() = || {
+                fn assert_struct_zerocopy_impl<T: ZeroCopy<#config_path>>() {}
+                assert_struct_zerocopy_impl::<#ident>()
+            };
+
             // Assert all fields implement `ZeroCopy`.
             const _assert_field_zerocopy_impl: fn() = || {
                 fn assert_field_zerocopy_impl<T: ZeroCopy<#config_path>>() {}


### PR DESCRIPTION
currently `wincode(assert_zero_copy)` does not check for `ZeroCopy` impl for the struct itself. the following code is unable to compile. Semantically, `assert_zero_copy` should already ensure it implements `ZeroCopy` but it did not

```rust
#[derive(SchemaWrite, PartialEq, Eq, Debug)]
#[wincode(internal, assert_zero_copy)]
#[repr(C)]
struct Foo { x: u8 }

// manually impl SchemaRead
unsafe impl<'de> SchemaRead<'de, DefaultConfig> for Foo {
    type Dst = Foo;

    const TYPE_META: TypeMeta = TypeMeta::Static {
        size: 1,
        zero_copy: true,
    };

    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
        let x = <u8 as SchemaRead<'de, DefaultConfig>>::get(reader)?;
        dst.write(Foo { x });
        Ok(())
    }
}

fn test() {
    let foo = Foo { x: 42 };
    let bytes = serialize(&foo).unwrap();
    let _borrowed: &Foo = wincode::deserialize(&bytes).unwrap();
}
```