### PR TITLE
fix(docs): make comment relate to SkipMode instead of attributes

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -45,10 +45,8 @@ pub(crate) struct Field {
     /// Opt out of writing or reading this field.
     ///
     /// The field will be initialized using one of the available modes:
-    /// ```
-    /// #[wincode(skip)] or #[wincode(skip(default))] // using Default::default()
-    /// #[wincode(skip(default_val = val))] // using provided value (typically constant expression)
-    /// ```
+    /// * `SkipMode::Default` - using `Default::default()`
+    /// * `SkipMode::DefaultVal(expr)` - using value provided by (typically constant) `expr`
     pub(crate) skip: Option<SkipMode>,
 }
 


### PR DESCRIPTION
The current comment for `skip` field in `wincode_derive::common::Field` mentions end-user attributes, while it should document internal `SkipMode` struct.

Additionally, currently the code quotes make it fail `cargo test`:
```
---- wincode-derive/src/common.rs - common::Field::skip (line 48) stdout ----
error: expected `;`, found `#`
 --> wincode-derive/src/common.rs:49:20
  |
3 | #[wincode(skip)] or #[wincode(skip(default))] // using Default::default()
  | ----------------   ^- unexpected token
  | |                  |
  | |                  expected `;` here
```
