### PR TITLE
fix: rand version bump `random` export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         run: cargo clippy --all-targets --features alloc -- -D warnings
       - name: tests
         run: cargo test --all-features --all-targets --no-fail-fast --workspace
+      - name: test doc
+        run: cargo test --all-features --doc --no-fail-fast --workspace
       - name: test uuid no serde compat
         run: cargo test uuid --features alloc,uuid --all-targets --no-fail-fast --workspace
 

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! # #[cfg(all(feature = "solana-short-vec", feature = "alloc"))] {
-//! # use rand::prelude::*;
+//! # use rand::random;
 //! # use wincode::{Serialize, Deserialize, len::{BincodeLen, ShortU16}, containers::{self, Pod}};
 //! # use wincode_derive::{SchemaWrite, SchemaRead};
 //! # use std::array;


### PR DESCRIPTION
dependabot bumped the `rand` crate, but didn't update a doctest using it. Added additional CI step to ensure doctests are exercised -- apparently `--all-targets` doesn't run doc tests.