### PR TITLE
Bump wincode-derive to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ rust-version = "1.84.1"
 [workspace.dependencies]
 quote = "1.0.44"
 proc-macro2 = "1.0.106"
-
-[patch.crates-io]
-wincode-derive = { path = "wincode-derive" }

--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode-derive"
-version = "0.3.1"
+version = "0.4.0"
 authors.workspace = true
 description = "Derive macros for wincode"
 repository.workspace = true

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -31,7 +31,7 @@ uuid-serde-compat = ["uuid"]
 pastey = "0.2.1"
 solana-short-vec = { version = "3.2.0", optional = true }
 thiserror = { version = "2.0.18", default-features = false }
-wincode-derive = { version = "0.3.1", optional = true }
+wincode-derive = { path = "../wincode-derive", version = "0.4.0", optional = true }
 uuid = { version = "1.20.0", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This version includes the following bug fixes and features for `wincode-derive`:

- https://github.com/anza-xyz/wincode/pull/73
- https://github.com/anza-xyz/wincode/pull/114
- https://github.com/anza-xyz/wincode/pull/124
- https://github.com/anza-xyz/wincode/pull/146
- https://github.com/anza-xyz/wincode/pull/150
- https://github.com/anza-xyz/wincode/pull/152

[Full commit diff](https://github.com/anza-xyz/wincode/compare/wincode@v0.3.1...wincode-derive-0.3.2)