### PR TITLE
chore(cargo): default-features = false on solana-short-vec

### DIFF
--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -29,7 +29,7 @@ uuid-serde-compat = ["uuid"]
 
 [dependencies]
 pastey = "0.2.1"
-solana-short-vec = { version = "3.2.0", optional = true }
+solana-short-vec = { version = "3.2.0", default-features = false, optional = true }
 thiserror = { version = "2.0.18", default-features = false }
 wincode-derive = { path = "../wincode-derive", version = "0.4.0", optional = true }
 uuid = { version = "1.20.0", optional = true, default-features = false }


### PR DESCRIPTION
`solana-short-vec` enables the `serde` feature by default. Since https://github.com/anza-xyz/wincode/pull/47, we no longer need the `serde` feature enabled.