### PR TITLE
fix: Result impl should use SchemaRead TYPE_META on TagEncoding

### DIFF
--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -707,7 +707,7 @@ where
     const TYPE_META: TypeMeta = match (
         T::TYPE_META,
         E::TYPE_META,
-        <C::TagEncoding as SchemaWrite<C>>::TYPE_META,
+        <C::TagEncoding as SchemaRead<C>>::TYPE_META,
     ) {
         (
             TypeMeta::Static { size: t_size, .. },


### PR DESCRIPTION
The `SchemaRead` impl for `Result` is using  `<C::TagEncoding as SchemaWrite<C>>::TYPE_META` in its `TypeMeta` calculation. It should use `<C::TagEncoding as SchemaRead<C>>::TYPE_META`.

Generally the TagEncoding will be one of the primitive integer types, which use the same `TypeMeta` for both `SchemaRead` and `SchemaWrite`, but better to correct here.