### PR TITLE
Deprecate the `Pod<_>` type

### DIFF
--- a/wincode/src/len.rs
+++ b/wincode/src/len.rs
@@ -604,10 +604,7 @@ pub mod short_vec {
     mod tests {
         use {
             super::*,
-            crate::{
-                containers::{self, Pod},
-                proptest_config::proptest_cfg,
-            },
+            crate::{containers, proptest_config::proptest_cfg},
             alloc::vec::Vec,
             proptest::prelude::*,
             solana_short_vec::ShortU16,
@@ -628,10 +625,10 @@ pub mod short_vec {
         #[wincode(internal)]
         struct ShortVecStruct {
             #[serde(with = "solana_short_vec")]
-            #[wincode(with = "containers::Vec<Pod<u8>, ShortU16>")]
+            #[wincode(with = "containers::Vec<u8, ShortU16>")]
             bytes: Vec<u8>,
             #[serde(with = "solana_short_vec")]
-            #[wincode(with = "containers::Vec<Pod<[u8; 32]>, ShortU16>")]
+            #[wincode(with = "containers::Vec<[u8; 32], ShortU16>")]
             ar: Vec<[u8; 32]>,
         }
 

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -105,7 +105,7 @@
 //! `wincode` can solve this with the following:
 //! ```
 //! # #[cfg(all(feature = "alloc", feature = "derive"))] {
-//! # use wincode::{Serialize as _, Deserialize as _, containers::{self, Pod}};
+//! # use wincode::{Serialize as _, Deserialize as _, containers};
 //! # use wincode_derive::{SchemaWrite, SchemaRead};
 //! mod foreign_crate {
 //!     // Defined in some foreign crate...
@@ -129,11 +129,16 @@
 //!     }
 //! }
 //!
+//! wincode::pod_wrapper! {
+//!     unsafe struct PodAddress(foreign_crate::Address);
+//!     unsafe struct PodHash(foreign_crate::Hash);
+//! }
+//!
 //! #[derive(SchemaWrite, SchemaRead)]
 //! #[wincode(from = "foreign_crate::A")]
 //! pub struct MyA {
-//!     addresses: Vec<Pod<foreign_crate::Address>>,
-//!     hash: Pod<foreign_crate::Hash>,
+//!     addresses: Vec<PodAddress>,
+//!     hash: PodHash,
 //! }
 //!
 //! let val = foreign_crate::A {

--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -1,6 +1,6 @@
 //! This module provides specialized implementations of standard library collection types that
 //! provide control over the length encoding (see [`SeqLen`](crate::len::SeqLen)), as well
-//! as special case opt-in raw-copy overrides (see [`Pod`]).
+//! as special case opt-in raw-copy overrides (see [`pod_wrapper!`]).
 //!
 //! # Examples
 //! Raw byte vec with solana short vec length encoding:
@@ -126,23 +126,23 @@ pub struct Rc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 /// Like [`Box`], for [`Arc`].
 pub struct Arc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 
-/// Indicates that the type is represented by raw bytes and does not have any invalid bit patterns.
+/// Creates a wrapper type for a type that is represented by raw bytes and does not have any invalid
+/// bit patterns.
 ///
-/// By opting into `Pod`, you are telling wincode that it can serialize and deserialize a type
-/// with a single memcpy -- it wont pay attention to things like struct layout, endianness, or anything
-/// else that would require validity or bit pattern checks. This is a very strong claim to make,
-/// so be sure that your type adheres to those requirements.
+/// By using `pod_wrapper!`, you are telling wincode that it can serialize and deserialize a type
+/// with a single memcpy -- it wont pay attention to things like struct layout, endianness, or
+/// anything else that would require validity or bit pattern checks. This is a very strong claim to
+/// make, so be sure that your type adheres to those requirements.
 ///
 /// Composable with sequence [`containers`](self) or compound types (structs, tuples) for
 /// an optimized read/write implementation.
-///
 ///
 /// This can be useful outside of sequences as well, for example on newtype structs
 /// containing byte arrays with `#[repr(transparent)]`.
 ///
 /// ---
-/// 💡 **Note:** as of `wincode` `0.2.0`, `Pod` is no longer needed for types that wincode can determine
-/// are "Pod-safe".
+/// 💡 **Note:** as of `wincode` `0.2.0`, `pod_wrapper!` is no longer needed for types that wincode
+/// can determine are "memcpy-safe".
 ///
 /// This includes:
 /// - [`u8`]
@@ -154,26 +154,27 @@ pub struct Arc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 /// Similarly, using built-in std collections like `Vec<T>` or `Box<[T]>` where `T` is one of the
 /// above will also be automatically optimized.
 ///
-/// You'll really only need to reach for [`Pod`] when dealing with foreign types for which you cannot
-/// derive `SchemaWrite` or `SchemaRead`. Or you're in a controlled scenario where you explicitly
-/// want to avoid endianness or layout checks.
+/// You'll really only need to reach for [`pod_wrapper!`] when dealing with foreign types for which
+/// you cannot derive `SchemaWrite` or `SchemaRead`. Or you're in a controlled scenario where you
+/// explicitly want to avoid endianness or layout checks.
 ///
 /// # Safety
 ///
 /// - The type must allow any bit pattern (e.g., no `bool`s, no `char`s, etc.)
-/// - If used on a compound type like a struct, all fields must be also be `Pod`, its
-///   layout must be guaranteed (via `#[repr(transparent)]` or `#[repr(C)]`), and the struct
-///   must not have any padding.
+/// - If used on a compound type like a struct, all fields must be also be memcpy-able, its layout
+///   must be guaranteed (via `#[repr(transparent)]` or `#[repr(C)]`), and the struct must not have
+///   any padding.
 /// - Must not contain references or pointers (includes types like `Vec` or `Box`).
-///     - Note, you may use `Pod` *inside* types like `Vec` or `Box`, e.g., `Vec<Pod<T>>` or `Box<[Pod<T>]>`,
-///       but specifying `Pod` on the outer type is invalid.
+///     - Note, you may use `pod_wrapper!` created types *inside* types like `Vec` or `Box`, e.g.,
+///       `Vec<PodT>` or `Box<[PodT]>`, but using `pod_wrapper!` on the outer type is invalid.
 ///
 /// # Examples
 ///
-/// A repr-transparent newtype struct containing a byte array where you cannot derive `SchemaWrite` or `SchemaRead`:
+/// A repr-transparent newtype struct containing a byte array where you cannot derive `SchemaWrite`
+/// or `SchemaRead`:
 /// ```
 /// # #[cfg(all(feature = "alloc", feature = "derive"))] {
-/// # use wincode::{containers::{self, Pod}};
+/// # use wincode::containers;
 /// # use wincode_derive::{SchemaWrite, SchemaRead};
 /// # use serde::{Serialize, Deserialize};
 /// # use std::array;
@@ -181,9 +182,13 @@ pub struct Arc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 /// #[repr(transparent)]
 /// struct Address([u8; 32]);
 ///
+/// wincode::pod_wrapper! {
+///     unsafe struct PodAddress(Address);
+/// }
+///
 /// #[derive(Serialize, Deserialize, SchemaWrite, SchemaRead)]
 /// struct MyStruct {
-///     #[wincode(with = "Pod<_>")]
+///     #[wincode(with = "PodAddress")]
 ///     address: Address
 /// }
 ///
@@ -195,6 +200,65 @@ pub struct Arc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 /// assert_eq!(wincode_bytes, bincode_bytes);
 /// # }
 /// ```
+#[macro_export]
+macro_rules! pod_wrapper {
+    ($(unsafe struct $name:ident($type:ty);)*) => {$(
+        struct $name where $type: Copy + 'static;
+
+        // SAFETY:
+        // - By using `pod_wrapper`, user asserts that the type is zero-copy, given the contract of
+        //   pod_wrapper:
+        //   - The type's in‑memory representation is exactly its serialized bytes.
+        //   - It can be safely initialized by memcpy (no validation, no endianness/layout work).
+        //   - Does not contain references or pointers.
+        unsafe impl<C: $crate::config::ConfigCore> $crate::config::ZeroCopy<C> for $name {}
+
+        unsafe impl<C: $crate::config::ConfigCore> $crate::SchemaWrite<C> for $name {
+            type Src = $type;
+
+            const TYPE_META: $crate::TypeMeta = $crate::TypeMeta::Static {
+                size: size_of::<$type>(),
+                zero_copy: true,
+            };
+
+            #[inline]
+            fn size_of(_: &$type) -> $crate::WriteResult<usize> {
+                Ok(size_of::<$type>())
+            }
+
+            #[inline]
+            fn write(mut writer: impl $crate::io::Writer, src: &$type) -> $crate::WriteResult<()> {
+                unsafe {
+                    Ok(writer.write_t(src)?)
+                }
+            }
+        }
+
+        unsafe impl<'de, C: $crate::config::ConfigCore> $crate::SchemaRead<'de, C> for $name {
+            type Dst = $type;
+
+            const TYPE_META: $crate::TypeMeta = $crate::TypeMeta::Static {
+                size: size_of::<$type>(),
+                zero_copy: true,
+            };
+
+            fn read(mut reader: impl $crate::io::Reader<'de>, dst: &mut core::mem::MaybeUninit<$type>) -> $crate::ReadResult<()> {
+                unsafe {
+                    Ok(reader.copy_into_t(dst)?)
+                }
+            }
+        }
+    )*}
+}
+pub use pod_wrapper;
+
+/// Indicates that the type is represented by raw bytes and does not have any invalid bit patterns.
+///
+/// Prefer [`pod_wrapper!`] instead.
+#[deprecated(
+    since = "0.4.6",
+    note = "This unsound type has been replaced by the `pod_wrapper!` macro."
+)]
 pub struct Pod<T: Copy + 'static>(PhantomData<T>);
 
 // SAFETY:
@@ -202,8 +266,10 @@ pub struct Pod<T: Copy + 'static>(PhantomData<T>);
 //   - The type's in‑memory representation is exactly its serialized bytes.
 //   - It can be safely initialized by memcpy (no validation, no endianness/layout work).
 //   - Does not contain references or pointers.
+#[allow(deprecated)]
 unsafe impl<T, C: ConfigCore> ZeroCopy<C> for Pod<T> where T: Copy + 'static {}
 
+#[allow(deprecated)]
 unsafe impl<T, C: ConfigCore> SchemaWrite<C> for Pod<T>
 where
     T: Copy + 'static,
@@ -227,6 +293,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 unsafe impl<'de, T, C: ConfigCore> SchemaRead<'de, C> for Pod<T>
 where
     T: Copy + 'static,

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -1417,7 +1417,7 @@ mod zero_copy {
                 // In this crate, `zero_copy: true` means:
                 // - The type's in‑memory representation is exactly its serialized bytes.
                 // - It can be safely initialized by memcpy (no validation, no endianness/layout work).
-                // - Containers may bulk-copy elements (e.g., Vec/BoxedSlice memcpy fast path for Pod).
+                // - Containers may bulk-copy elements (e.g., Vec/BoxedSlice memcpy fast path).
                 // - It can be deserialized by reference to some underlying source bytes.
                 //
                 // A _reference_ to a zero-copy type does not meet that contract:

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -5,7 +5,7 @@
 //! ```
 //! # #[cfg(all(feature = "solana-short-vec", feature = "alloc"))] {
 //! # use rand::random;
-//! # use wincode::{Serialize, Deserialize, len::{BincodeLen, ShortU16}, containers::{self, Pod}};
+//! # use wincode::{Serialize, Deserialize, len::{BincodeLen, ShortU16}, containers};
 //! # use wincode_derive::{SchemaWrite, SchemaRead};
 //! # use std::array;
 //!
@@ -18,12 +18,17 @@
 //! #[derive(Clone, Copy)]
 //! struct Address([u8; 32]);
 //!
+//! wincode::pod_wrapper! {
+//!     unsafe struct PodSignature(Signature);
+//!     unsafe struct PodAddress(Address);
+//! }
+//!
 //! # #[derive(SchemaWrite, SchemaRead, serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
 //! struct MyStruct {
-//!     #[wincode(with = "containers::Vec<Pod<_>, BincodeLen>")]
+//!     #[wincode(with = "containers::Vec<PodSignature, BincodeLen>")]
 //!     signature: Vec<Signature>,
 //!     #[serde(with = "solana_short_vec")]
-//!     #[wincode(with = "containers::Vec<Pod<_>, ShortU16>")]
+//!     #[wincode(with = "containers::Vec<PodAddress, ShortU16>")]
 //!     address: Vec<Address>,
 //! }
 //!
@@ -500,11 +505,11 @@ mod tests {
     use {
         crate::{
             config::{self, Config, Configuration, DefaultConfig},
-            containers::{self, Pod},
-            deserialize, deserialize_mut,
+            containers, deserialize, deserialize_mut,
             error::{self, invalid_tag_encoding},
             io::{Reader, Writer},
             len::{BincodeLen, FixIntLen},
+            pod_wrapper,
             proptest_config::proptest_cfg,
             serialize, Deserialize, ReadResult, SchemaRead, SchemaWrite, Serialize, TypeMeta,
             UninitBuilder, WriteResult, ZeroCopy,
@@ -1393,9 +1398,8 @@ mod tests {
         #[derive(UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]
         struct Test {
-            #[wincode(with = "containers::Vec<Pod<_>, BincodeLen>")]
+            #[wincode(with = "containers::Vec<_, BincodeLen>")]
             a: Vec<u8>,
-            #[wincode(with = "containers::Pod<_>")]
             b: [u8; 32],
             c: u64,
         }
@@ -1458,8 +1462,8 @@ mod tests {
         #[wincode(internal, from = "Test")]
         #[allow(unused)]
         struct TestMapped {
-            a: containers::Vec<containers::Pod<u8>, BincodeLen>,
-            b: containers::Pod<[u8; 32]>,
+            a: containers::Vec<u8, BincodeLen>,
+            b: [u8; 32],
             c: u64,
         }
 
@@ -1776,14 +1780,8 @@ mod tests {
         )]
         #[wincode(internal)]
         enum Enum {
-            A {
-                name: String,
-                id: u64,
-            },
-            B(
-                String,
-                #[wincode(with = "containers::Vec<Pod<_>, BincodeLen>")] Vec<u8>,
-            ),
+            A { name: String, id: u64 },
+            B(String, Vec<u8>),
             C,
         }
 
@@ -2363,7 +2361,11 @@ mod tests {
         #[allow(dead_code)]
         struct Signature([u8; 64]);
 
-        type Target = containers::Box<[Pod<Signature>], BincodeLen>;
+        pod_wrapper! {
+            unsafe struct PodSignature(Signature);
+        }
+
+        type Target = containers::Box<[PodSignature], BincodeLen>;
         proptest!(proptest_cfg(), |(slice in proptest::collection::vec(any::<Signature>(), 1..=32).prop_map(|vec| vec.into_boxed_slice()))| {
             let serialized = Target::serialize(&slice).unwrap();
             // Deliberately trigger the drop with a failed deserialization
@@ -2829,7 +2831,7 @@ mod tests {
         #[test]
         fn test_option_container(option in proptest::option::of(any::<[u8; 32]>())) {
             let bincode_serialized = bincode::serialize(&option).unwrap();
-            type Target = Option<Pod<[u8; 32]>>;
+            type Target = Option<[u8; 32]>;
             let schema_serialized = Target::serialize(&option).unwrap();
             prop_assert_eq!(&bincode_serialized, &schema_serialized);
             let bincode_deserialized: Option<[u8; 32]> = bincode::deserialize(&bincode_serialized).unwrap();
@@ -3009,7 +3011,7 @@ mod tests {
         ) {
             let bincode_serialized = bincode::serialize(&tuple).unwrap();
             type BincodeTarget = (StructNonStatic, [u8; 32], Vec<StructStatic>);
-            type Target = (StructNonStatic, Pod<[u8; 32]>, Vec<StructStatic>);
+            type Target = (StructNonStatic, [u8; 32], Vec<StructStatic>);
             let schema_serialized = Target::serialize(&tuple).unwrap();
 
             prop_assert_eq!(&bincode_serialized, &schema_serialized);
@@ -3230,11 +3232,15 @@ mod tests {
         #[repr(transparent)]
         struct Address([u8; 64]);
 
+        pod_wrapper! {
+            unsafe struct PodAddress(Address);
+        }
+
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]
         #[repr(C)]
         struct MyStruct {
-            #[wincode(with = "Pod<_>")]
+            #[wincode(with = "PodAddress")]
             address: Address,
         }
 
@@ -3262,17 +3268,21 @@ mod tests {
         #[repr(transparent)]
         struct Address([u8; 64]);
 
+        pod_wrapper! {
+            unsafe struct PodAddress(Address);
+        }
+
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Eq)]
         #[wincode(internal)]
         struct MyStructRef<'a> {
-            #[wincode(with = "&'a Pod<Address>")]
+            #[wincode(with = "&'a PodAddress")]
             address: &'a Address,
         }
 
         #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]
         struct MyStruct {
-            #[wincode(with = "Pod<_>")]
+            #[wincode(with = "PodAddress")]
             address: Address,
         }
 


### PR DESCRIPTION
Create a replacement `pod_wrapper!` which can wrap types to allow for memcpy de-/serialization.

Once the deprecated `Pod<_>` type is removed, #89 will be fixed.