### PR TITLE
chore: Remove deprecated `Elem` container

### DIFF
--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -126,15 +126,6 @@ pub struct Rc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 /// Like [`Box`], for [`Arc`].
 pub struct Arc<T: ?Sized, Len>(PhantomData<T>, PhantomData<Len>);
 
-/// Indicates that the type is an element of a sequence, composable with [`containers`](self).
-///
-/// Prefer [`Pod`] for types representable as raw bytes.
-#[deprecated(
-    since = "0.2.0",
-    note = "Elem is no longer needed for container usage. Use `T` directly instead."
-)]
-pub struct Elem<T>(PhantomData<T>);
-
 /// Indicates that the type is represented by raw bytes and does not have any invalid bit patterns.
 ///
 /// By opting into `Pod`, you are telling wincode that it can serialize and deserialize a type
@@ -250,49 +241,6 @@ where
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         // SAFETY: `T` is plain ol' data.
         unsafe { Ok(reader.copy_into_t(dst)?) }
-    }
-}
-
-// Provide `SchemaWrite` implementation for `Elem<T>` for backwards compatibility.
-//
-// Container impls use blanket implementations over `T` where `T` is `SchemaWrite`,
-// so this preserves existing behavior, such that `Elem<T>` behaves exactly like `T`.
-#[allow(deprecated)]
-unsafe impl<T, C: ConfigCore> SchemaWrite<C> for Elem<T>
-where
-    T: SchemaWrite<C>,
-{
-    type Src = T::Src;
-
-    const TYPE_META: TypeMeta = T::TYPE_META;
-
-    #[inline]
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        T::size_of(src)
-    }
-
-    #[inline]
-    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
-        T::write(writer, src)
-    }
-}
-
-// Provide `SchemaRead` implementation for `Elem<T>` for backwards compatibility.
-//
-// Container impls use blanket implementations over `T` where `T` is `SchemaRead`,
-// so this preserves existing behavior, such that `Elem<T>` behaves exactly like `T`.
-#[allow(deprecated)]
-unsafe impl<'de, T, C: ConfigCore> SchemaRead<'de, C> for Elem<T>
-where
-    T: SchemaRead<'de, C>,
-{
-    type Dst = T::Dst;
-
-    const TYPE_META: TypeMeta = T::TYPE_META;
-
-    #[inline]
-    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        T::read(reader, dst)
     }
 }
 

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -406,12 +406,12 @@ where
 
 #[cfg(all(test, feature = "std", feature = "derive"))]
 mod tests {
-    #![allow(clippy::arithmetic_side_effects, deprecated)]
+    #![allow(clippy::arithmetic_side_effects)]
 
     use {
         crate::{
             config::{self, Config, Configuration, DefaultConfig},
-            containers::{self, Elem, Pod},
+            containers::{self, Pod},
             deserialize, deserialize_mut,
             error::{self, invalid_tag_encoding},
             io::{Reader, Writer},
@@ -2225,30 +2225,6 @@ mod tests {
             let bincode_deserialized: char = bincode::deserialize(&bincode_serialized).unwrap();
             let schema_deserialized: char = deserialize(&schema_serialized).unwrap();
             prop_assert_eq!(val, bincode_deserialized);
-            prop_assert_eq!(val, schema_deserialized);
-        }
-
-        #[test]
-        fn test_elem_compat(val in any::<StructStatic>()) {
-            let bincode_serialized = bincode::serialize(&val).unwrap();
-            let schema_serialized = <Elem<StructStatic>>::serialize(&val).unwrap();
-            prop_assert_eq!(&bincode_serialized, &schema_serialized);
-
-            let bincode_deserialized: StructStatic = bincode::deserialize(&bincode_serialized).unwrap();
-            let schema_deserialized: StructStatic = <Elem<StructStatic>>::deserialize(&schema_serialized).unwrap();
-            prop_assert_eq!(&val, &bincode_deserialized);
-            prop_assert_eq!(val, schema_deserialized);
-        }
-
-        #[test]
-        fn test_elem_vec_compat(val in proptest::collection::vec(any::<StructStatic>(), 0..=100)) {
-            let bincode_serialized = bincode::serialize(&val).unwrap();
-            let schema_serialized = <containers::Vec<Elem<StructStatic>, BincodeLen>>::serialize(&val).unwrap();
-            prop_assert_eq!(&bincode_serialized, &schema_serialized);
-
-            let bincode_deserialized: Vec<StructStatic> = bincode::deserialize(&bincode_serialized).unwrap();
-            let schema_deserialized = <containers::Vec<Elem<StructStatic>, BincodeLen>>::deserialize(&schema_serialized).unwrap();
-            prop_assert_eq!(&val, &bincode_deserialized);
             prop_assert_eq!(val, schema_deserialized);
         }
 


### PR DESCRIPTION
`Elem` was deprecated in `0.2.0`. Deleting that code since we're now 2 minor versions from `0.2`.