### PR TITLE
Add `by_ref` function to `Reader` and `Writer` traits

### DIFF
--- a/wincode-derive/src/lib.rs
+++ b/wincode-derive/src/lib.rs
@@ -60,7 +60,7 @@ pub fn derive_schema_read(input: TokenStream) -> TokenStream {
 ///         // Deserializes a `Vec<u8>` into the `payload` slot of `Message` and marks the field
 ///         // as initialized. If the subsequent `read_bytes` call fails, the `payload` field will
 ///         // be dropped.
-///         msg_builder.read_payload(&mut reader)?;
+///         msg_builder.read_payload(reader.by_ref())?;
 ///         msg_builder.read_bytes(reader)?;
 ///         msg_builder.finish();
 ///     }

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -71,7 +71,7 @@ fn impl_struct(
             } else {
                 quote! {
                     <#target as SchemaRead<'de, WincodeConfig>>::read(
-                        &mut reader,
+                        reader.by_ref(),
                         unsafe { &mut *(&raw mut (*dst_ptr).#ident).cast::<#hint>() }
                     )?;
                     #init_count
@@ -201,7 +201,7 @@ fn impl_enum(
                             quote! { let #ident = #val; }
                         } else {
                             quote! {
-                                let #ident = <#target as SchemaRead<'de, WincodeConfig>>::get(&mut reader)?;
+                                let #ident = <#target as SchemaRead<'de, WincodeConfig>>::get(reader.by_ref())?;
                             }
                         };
                         construct_idents.push(ident);
@@ -255,11 +255,11 @@ fn impl_enum(
 
     let read_discriminant = if let Some(tag_encoding) = tag_encoding_override {
         quote! {
-            <#tag_encoding as SchemaRead<'de, WincodeConfig>>::get(&mut reader)?;
+            <#tag_encoding as SchemaRead<'de, WincodeConfig>>::get(reader.by_ref())?;
         }
     } else {
         quote! {
-            WincodeConfig::TagEncoding::try_into_u32(WincodeConfig::TagEncoding::get(&mut reader)?)?
+            WincodeConfig::TagEncoding::try_into_u32(WincodeConfig::TagEncoding::get(reader.by_ref())?)?
         }
     };
 

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -43,7 +43,7 @@ fn impl_struct(
         .filter_map(|(field, ident)| {
             if field.skip.is_none() {
                 let target = field.target_resolved();
-                let write = quote! { <#target as SchemaWrite<WincodeConfig>>::write(&mut writer, &src.#ident)?; };
+                let write = quote! { <#target as SchemaWrite<WincodeConfig>>::write(writer.by_ref(), &src.#ident)?; };
                 size_count_idents.push(ident);
                 Some(write)
             } else {
@@ -114,7 +114,7 @@ fn impl_enum(
                     <#tag_encoding as SchemaWrite<WincodeConfig>>::size_of(&#discriminant)?
                 },
                 quote! {
-                    <#tag_encoding as SchemaWrite<WincodeConfig>>::write(&mut writer, &#discriminant)?
+                    <#tag_encoding as SchemaWrite<WincodeConfig>>::write(writer.by_ref(), &#discriminant)?
                 },
             )
         } else {
@@ -123,7 +123,7 @@ fn impl_enum(
                     WincodeConfig::TagEncoding::size_of_from_u32(#discriminant)?
                 },
                 quote! {
-                    WincodeConfig::TagEncoding::write_from_u32(&mut writer, #discriminant)?
+                    WincodeConfig::TagEncoding::write_from_u32(writer.by_ref(), #discriminant)?
                 },
             )
         };
@@ -139,7 +139,7 @@ fn impl_enum(
                         if field.skip.is_none() {
                             let target = field.target_resolved();
                             let write = quote! {
-                                <#target as SchemaWrite<WincodeConfig>>::write(&mut writer, #ident)?;
+                                <#target as SchemaWrite<WincodeConfig>>::write(writer.by_ref(), #ident)?;
                             };
                             pattern_fragments.push(quote! { #ident });
                             size_count_idents.push(ident);

--- a/wincode/src/config/serde.rs
+++ b/wincode/src/config/serde.rs
@@ -18,7 +18,7 @@ pub trait Serialize<C: Config>: SchemaWrite<C> {
         let capacity = Self::size_of(src)?;
         let mut buffer = Vec::with_capacity(capacity);
         let mut writer = buffer.spare_capacity_mut();
-        Self::serialize_into(&mut writer, src, config)?;
+        Self::serialize_into(writer.by_ref(), src, config)?;
         let len = writer.len();
         unsafe {
             #[allow(clippy::arithmetic_side_effects)]
@@ -31,7 +31,7 @@ pub trait Serialize<C: Config>: SchemaWrite<C> {
     #[inline]
     #[expect(unused_variables)]
     fn serialize_into(mut dst: impl Writer, src: &Self::Src, config: C) -> WriteResult<()> {
-        Self::write(&mut dst, src)?;
+        Self::write(dst.by_ref(), src)?;
         dst.finish()?;
         Ok(())
     }

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -507,15 +507,15 @@
 //!                 payload_builder.init_header_with(|header| {
 //!                     // Read directly into the projected MaybeUninit<Header> slot.
 //!                     let mut header_builder = HeaderUninitBuilder::<C>::from_maybe_uninit_mut(header);
-//!                     header_builder.read_num_required_signatures(&mut reader)?;
-//!                     header_builder.read_num_signed_accounts(&mut reader)?;
-//!                     header_builder.read_num_unsigned_accounts(&mut reader)?;
+//!                     header_builder.read_num_required_signatures(reader.by_ref())?;
+//!                     header_builder.read_num_signed_accounts(reader.by_ref())?;
+//!                     header_builder.read_num_unsigned_accounts(reader.by_ref())?;
 //!                     header_builder.finish();
 //!                     Ok(())
 //!                 })?;
-//!                 // Alternatively, we could have done `payload_builder.read_header(&mut reader)?;`
+//!                 // Alternatively, we could have done `payload_builder.read_header(reader.by_ref())?;`
 //!                 // rather than reading all the fields individually.
-//!                 payload_builder.read_data(&mut reader)?;
+//!                 payload_builder.read_data(reader.by_ref())?;
 //!                 // Payload is fully initialized, so we forget the builder
 //!                 // to avoid dropping the initialized fields.
 //!                 payload_builder.finish();

--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -273,7 +273,7 @@ where
     type Dst = vec::Vec<T::Dst>;
 
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let len = Len::read_prealloc_check::<T::Dst>(&mut reader)?;
+        let len = Len::read_prealloc_check::<T::Dst>(reader.by_ref())?;
         let mut vec: vec::Vec<T::Dst> = vec::Vec::with_capacity(len);
 
         match T::TYPE_META {
@@ -296,7 +296,7 @@ where
                 // will consume `size * len` bytes, fully consuming the trusted window.
                 let mut reader = unsafe { reader.as_trusted_for(size * len) }?;
                 for i in 0..len {
-                    T::read(&mut reader, unsafe { &mut *ptr })?;
+                    T::read(reader.by_ref(), unsafe { &mut *ptr })?;
                     unsafe {
                         ptr = ptr.add(1);
                         #[allow(clippy::arithmetic_side_effects)]
@@ -308,7 +308,7 @@ where
             TypeMeta::Dynamic => {
                 let mut ptr = vec.as_mut_ptr().cast::<MaybeUninit<T::Dst>>();
                 for i in 0..len {
-                    T::read(&mut reader, unsafe { &mut *ptr })?;
+                    T::read(reader.by_ref(), unsafe { &mut *ptr })?;
                     unsafe {
                         ptr = ptr.add(1);
                         #[allow(clippy::arithmetic_side_effects)]
@@ -446,7 +446,7 @@ macro_rules! impl_heap_slice {
                     }
                 }
 
-                let len = Len::read_prealloc_check::<T::Dst>(&mut reader)?;
+                let len = Len::read_prealloc_check::<T::Dst>(reader.by_ref())?;
                 let mem = $target::<[T::Dst]>::new_uninit_slice(len);
                 let fat = $target::into_raw(mem) as *mut [MaybeUninit<T::Dst>];
 
@@ -480,7 +480,7 @@ macro_rules! impl_heap_slice {
                             // - The container is initialized with capacity for `len` elements, and `i` is guaranteed to be
                             //   less than `len`.
                             let slot = unsafe { &mut *raw_base.add(i) };
-                            T::read(&mut reader, slot)?;
+                            T::read(reader.by_ref(), slot)?;
                             guard.inner.inc_len();
                         }
 
@@ -498,7 +498,7 @@ macro_rules! impl_heap_slice {
                             // - The container is initialized with capacity for `len` elements, and `i` is guaranteed to be
                             //   less than `len`.
                             let slot = unsafe { &mut *raw_base.add(i) };
-                            T::read(&mut reader, slot)?;
+                            T::read(reader.by_ref(), slot)?;
                             guard.inner.inc_len();
                         }
 
@@ -553,7 +553,7 @@ where
             // fully initializing the trusted window.
             let mut writer = unsafe { writer.as_trusted_for(needed) }?;
 
-            Len::write(&mut writer, src.len())?;
+            Len::write(writer.by_ref(), src.len())?;
             let (front, back) = src.as_slices();
             // SAFETY:
             // - `T` is zero-copy eligible (no invalid bit patterns, no layout requirements, no endianness checks, etc.).

--- a/wincode/src/schema/external/uuid.rs
+++ b/wincode/src/schema/external/uuid.rs
@@ -31,7 +31,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for Uuid {
         // serde serializes byte slices as a length-prefixed array.
         #[cfg(feature = "uuid-serde-compat")]
         {
-            let len = C::LengthEncoding::read(&mut reader)?;
+            let len = C::LengthEncoding::read(reader.by_ref())?;
             if len != size_of::<Uuid>() {
                 return Err(crate::error::invalid_value("Uuid: invalid length prefix"));
             }
@@ -78,7 +78,7 @@ unsafe impl<C: Config> SchemaWrite<C> for Uuid {
     #[inline]
     fn write(mut writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
         #[cfg(feature = "uuid-serde-compat")]
-        C::LengthEncoding::write(&mut writer, size_of::<Uuid>())?;
+        C::LengthEncoding::write(writer.by_ref(), size_of::<Uuid>())?;
         writer.write(src.as_bytes())?;
         Ok(())
     }


### PR DESCRIPTION
Fixes #170

## Problem

Given the following recursive type:
```rs
#[derive(SchemaWrite, SchemaRead)]
pub enum Value {
    Usize(usize)
    List(Vec<Value>),
}
```
Serializing or deserialization yields the following error:
```
error[E0275]: overflow evaluating the requirement `TrustedSliceWriter<'_>: Writer`
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate
  = note: required for `&mut TrustedSliceWriter<'_>` to implement `Writer`
  = note: 128 redundant requirements hidden
  = note: required for `&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut ...` to implement `Writer`
```

The issue is that the signatures of `SchemaRead::read` and `SchemaWrite::write` rely on `impl Reader` / `impl Writer`, where that instance may already be of `&mut impl Reader` or `&mut impl Writer`, given the blanket implementation for mutable references to `Reader` and `Writer`.

https://github.com/anza-xyz/wincode/blob/0086e1c3b623cba13af7457756478fc187c0cca8/wincode/src/io/mod.rs#L222
https://github.com/anza-xyz/wincode/blob/0086e1c3b623cba13af7457756478fc187c0cca8/wincode/src/io/mod.rs#L417

On a recursive type, where implementations may pass `&mut reader` or `&mut writer` to nested member types to avoid moving the parameter, an unbounded mutable borrow chain is created, resulting in the above error.

## Solution

This PR introduces a `by_ref` method to `Reader` and `Writer`, which can be used in place of creating mutable borrows on `impl Reader` or `impl Writer`.

> Similar to [`std::io::Read::by_ref`](https://doc.rust-lang.org/std/io/trait.Read.html#method.by_ref)

Importantly, in the `by_ref` implementation for the blanket `&mut Reader` and `&mut Writer` implementations, we stop any recursion from occuring:
https://github.com/anza-xyz/wincode/blob/ddee7720eb981ad784b7c55994ff33d98ac5eb4f/wincode/src/io/mod.rs#L260-L263

By using `by_ref` at all callsites rather than `&mut reader` or `&mut writer`, the issue is resolved.

### Potential pitfalls

We don't have any way to enforce that users use `by_ref` instead of `&mut`. One possible way of enforcing this would be to remove blanket `&mut` implementations and introduce wrapper types `ReaderRef` and `WriterRef`, as discussed [here](https://github.com/anza-xyz/wincode/issues/170#issuecomment-3887431830). I am hesitant to remove those blanket implementations, as it is likely to break downstream code relying on it. I think this proposal is a reasonable middle ground -- all wincode supported implementations and derive macros use `by_ref`, which should cover the vast majority of use-cases. These functions provide good documentation to push users towards using `by_ref`. We also provide a default implementation for `by_ref` in the `Reader` and `Writer` traits, which should work in virtually all cases, so it is unlikely to break people downstream.