### PR TITLE
Bump toolchain and rust_version to 1.89.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 jobs:
@@ -13,15 +13,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-23
+          toolchain: nightly-2025-06-23
           components: rustfmt, miri, rust-src
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - name: rustfmt (check)
-        run: cargo +nightly-2024-11-23 fmt --all -- --check
+        run: cargo +nightly-2025-06-23 fmt --all -- --check
       - name: miri (check)
-        run: cargo +nightly-2024-11-23 miri test --all-features --lib --bins --no-fail-fast --workspace --exclude wincode-fuzz
+        run: cargo +nightly-2025-06-23 miri test --all-features --lib --bins --no-fail-fast --workspace --exclude wincode-fuzz
 
   lint-test:
     name: clippy & tests (MSRV)
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.84.1
+          toolchain: 1.89.0
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -52,12 +52,12 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: 1.88.0
+      RUSTUP_TOOLCHAIN: 1.89.0
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.88.0
+          toolchain: 1.89.0
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/anza-xyz/wincode"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.84.1"
+rust-version = "1.89.0"
 
 [workspace.dependencies]
 quote = "1.0.45"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.89.0"


### PR DESCRIPTION
We are using old toolchain, no harm in building with newest stable version, we set `rust-version` separately.