### PR TITLE
Serde compatibility

### DIFF
--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -20,8 +20,9 @@ rustdoc-args = ["--cfg", "docsrs", "-D", "warnings"]
 
 [features]
 default = ["std"]
-alloc = []
+alloc = ["serde?/alloc"]
 std = ["alloc", "thiserror/std"]
+serde = ["dep:serde"]
 solana-short-vec = ["dep:solana-short-vec"]
 derive = ["dep:wincode-derive"]
 uuid = ["dep:uuid"]
@@ -29,6 +30,7 @@ uuid-serde-compat = ["uuid"]
 
 [dependencies]
 pastey = "0.2.1"
+serde = { version = "1.0", default-features = false, optional = true }
 solana-short-vec = { version = "3.2.0", default-features = false, optional = true }
 thiserror = { version = "2.0.18", default-features = false }
 wincode-derive = { path = "../wincode-derive", version = "0.4.2", optional = true }

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -559,6 +559,8 @@ pub use serde::*;
 pub mod config;
 #[cfg(test)]
 mod proptest_config;
+#[cfg(feature = "serde")]
+pub mod serde_compat;
 #[cfg(feature = "derive")]
 pub use wincode_derive::*;
 // Include tuple impls.

--- a/wincode/src/serde_compat/de.rs
+++ b/wincode/src/serde_compat/de.rs
@@ -1,0 +1,426 @@
+//! Deserializer
+
+use {
+    crate::{error::ReadError, io::Reader, SchemaRead},
+    core::marker::PhantomData,
+    serde::de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor},
+    thiserror::Error,
+};
+
+const ANY_NOT_SUPPORTED: &str = "Wincode does not support serde's `any` decoding feature";
+const IDENTIFIER_NOT_SUPPORTED: &str = "Wincode does not support serde identifiers";
+const IGNORED_ANY_NOT_SUPPORTED: &str = "Wincode does not support serde's `ignored_any`";
+const SERDE_ERROR: &str = "serde error";
+
+#[cfg(not(feature = "alloc"))]
+const CANNOT_ALLOCATE: &str =
+    "Cannot allocate data like `String` and `Vec<u8>` without `alloc` feature";
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Bincode does not support serde's `any` decoding feature.
+    #[error("{ANY_NOT_SUPPORTED}")]
+    AnyNotSupported,
+    /// Could not allocate data like `String` and `Vec<u8>`
+    #[cfg(not(feature = "alloc"))]
+    #[error("{CANNOT_ALLOCATE}")]
+    CannotAllocate,
+    #[cfg(feature = "alloc")]
+    #[error("{msg}")]
+    CustomSerde { msg: alloc::string::String },
+    #[cfg(not(feature = "alloc"))]
+    #[error("{SERDE_ERROR}")]
+    CustomSerde,
+    /// Wincode does not support serde identifiers.
+    #[error("{IDENTIFIER_NOT_SUPPORTED}")]
+    IdentifierNotSupported,
+    /// Wincode does not support serde's `ignored_any`.
+    #[error("{IGNORED_ANY_NOT_SUPPORTED}")]
+    IgnoredAnyNotSupported,
+    #[error(transparent)]
+    Read(#[from] ReadError),
+}
+
+impl serde::de::Error for Error {
+    #[cfg(feature = "alloc")]
+    fn custom<T>(msg: T) -> Self
+    where
+        T: core::fmt::Display,
+    {
+        Self::CustomSerde {
+            msg: alloc::string::ToString::to_string(&msg),
+        }
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn custom<T>(_msg: T) -> Self
+    where
+        T: core::fmt::Display,
+    {
+        Self::CustomSerde
+    }
+}
+
+impl From<Error> for ReadError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::AnyNotSupported => Self::Custom(ANY_NOT_SUPPORTED),
+            #[cfg(not(feature = "alloc"))]
+            Error::CannotAllocate => Self::Custom(CANNOT_ALLOCATE),
+            #[cfg(feature = "alloc")]
+            Error::CustomSerde { msg: _ } => Self::Custom(SERDE_ERROR),
+            #[cfg(not(feature = "alloc"))]
+            Error::CustomSerde => Self::Custom(SERDE_ERROR),
+            Error::IdentifierNotSupported => Self::Custom(IDENTIFIER_NOT_SUPPORTED),
+            Error::IgnoredAnyNotSupported => Self::Custom(IGNORED_ANY_NOT_SUPPORTED),
+            Error::Read(err) => err,
+        }
+    }
+}
+
+pub struct Deserializer<R, C = crate::config::Configuration> {
+    inner: R,
+    marker: PhantomData<C>,
+}
+
+impl<R, C> Deserializer<R, C> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            inner: reader,
+            marker: PhantomData,
+        }
+    }
+}
+
+macro_rules! impl_fn {
+    ($deserialize_method:ident, $visit_method:ident, $visit_ty:ty) => {
+        fn $deserialize_method<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.$visit_method(<$visit_ty as SchemaRead<C>>::get(&mut self.inner)?)
+        }
+    };
+}
+
+impl<'de, C, R> serde::Deserializer<'de> for Deserializer<R, C>
+where
+    C: crate::config::Config,
+    R: Reader<'de>,
+{
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Self::Error::AnyNotSupported)
+    }
+
+    impl_fn!(deserialize_bool, visit_bool, bool);
+    impl_fn!(deserialize_i8, visit_i8, i8);
+    impl_fn!(deserialize_i16, visit_i16, i16);
+    impl_fn!(deserialize_i32, visit_i32, i32);
+    impl_fn!(deserialize_i64, visit_i64, i64);
+    impl_fn!(deserialize_i128, visit_i128, i128);
+    impl_fn!(deserialize_u8, visit_u8, u8);
+    impl_fn!(deserialize_u16, visit_u16, u16);
+    impl_fn!(deserialize_u32, visit_u32, u32);
+    impl_fn!(deserialize_u64, visit_u64, u64);
+    impl_fn!(deserialize_u128, visit_u128, u128);
+    impl_fn!(deserialize_f32, visit_f32, f32);
+    impl_fn!(deserialize_f64, visit_f64, f64);
+    impl_fn!(deserialize_char, visit_char, char);
+    impl_fn!(deserialize_str, visit_borrowed_str, &str);
+
+    #[cfg(feature = "alloc")]
+    impl_fn!(deserialize_string, visit_string, alloc::string::String);
+
+    #[cfg(not(feature = "alloc"))]
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Self::Error::CannotAllocate)
+    }
+
+    impl_fn!(deserialize_bytes, visit_borrowed_bytes, &[u8]);
+
+    #[cfg(feature = "alloc")]
+    impl_fn!(deserialize_byte_buf, visit_byte_buf, alloc::vec::Vec<u8>);
+
+    #[cfg(not(feature = "alloc"))]
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Self::Error::CannotAllocate)
+    }
+
+    fn deserialize_option<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let discriminant = <u8 as SchemaRead<C>>::get(&mut self.inner)?;
+        match discriminant {
+            0 => visitor.visit_none(),
+            1 => visitor.visit_some(self),
+            d => Err(ReadError::InvalidTagEncoding(d.into()).into()),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let len = <usize as SchemaRead<C>>::get(&mut self.inner)?;
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        struct Access<R, C> {
+            deserializer: Deserializer<R, C>,
+            len: usize,
+        }
+
+        impl<'de, C, R> SeqAccess<'de> for Access<R, C>
+        where
+            C: crate::config::Config,
+            R: Reader<'de>,
+        {
+            type Error = Error;
+
+            fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+            where
+                T: DeserializeSeed<'de>,
+            {
+                if self.len > 0 {
+                    self.len -= 1;
+                    let value = DeserializeSeed::deserialize(
+                        seed,
+                        Deserializer {
+                            inner: &mut self.deserializer.inner,
+                            marker: self.deserializer.marker,
+                        },
+                    )?;
+                    Ok(Some(value))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            fn size_hint(&self) -> Option<usize> {
+                Some(self.len)
+            }
+        }
+
+        visitor.visit_seq(Access {
+            deserializer: self,
+            len,
+        })
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        struct Access<R, C> {
+            deserializer: Deserializer<R, C>,
+            len: usize,
+        }
+
+        impl<'de, C, R> MapAccess<'de> for Access<R, C>
+        where
+            C: crate::config::Config,
+            R: Reader<'de>,
+        {
+            type Error = Error;
+
+            fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+            where
+                K: DeserializeSeed<'de>,
+            {
+                if self.len > 0 {
+                    self.len -= 1;
+                    let key = DeserializeSeed::deserialize(
+                        seed,
+                        Deserializer {
+                            inner: &mut self.deserializer.inner,
+                            marker: self.deserializer.marker,
+                        },
+                    )?;
+                    Ok(Some(key))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+            where
+                V: DeserializeSeed<'de>,
+            {
+                let value = DeserializeSeed::deserialize(
+                    seed,
+                    Deserializer {
+                        inner: &mut self.deserializer.inner,
+                        marker: self.deserializer.marker,
+                    },
+                )?;
+                Ok(value)
+            }
+
+            fn size_hint(&self) -> Option<usize> {
+                Some(self.len)
+            }
+        }
+
+        let len = <usize as SchemaRead<C>>::get(&mut self.inner)?;
+
+        visitor.visit_map(Access {
+            deserializer: self,
+            len,
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_tuple(fields.len(), visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_enum(self)
+    }
+
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        Err(Self::Error::IdentifierNotSupported)
+    }
+
+    fn deserialize_ignored_any<V>(self, _: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        Err(Self::Error::IgnoredAnyNotSupported)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+impl<'de, C, R> EnumAccess<'de> for Deserializer<R, C>
+where
+    C: crate::config::Config,
+    R: Reader<'de>,
+{
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        use serde::de::value::U32Deserializer;
+        let idx = <u32 as SchemaRead<C>>::get(&mut self.inner)?;
+        let val = seed.deserialize(U32Deserializer::<Self::Error>::new(idx))?;
+        Ok((val, self))
+    }
+}
+
+impl<'de, C, R> VariantAccess<'de> for Deserializer<R, C>
+where
+    C: crate::config::Config,
+    R: Reader<'de>,
+{
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        DeserializeSeed::deserialize(seed, self)
+    }
+
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        serde::Deserializer::deserialize_tuple(self, len, visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        serde::Deserializer::deserialize_tuple(self, fields.len(), visitor)
+    }
+}

--- a/wincode/src/serde_compat/mod.rs
+++ b/wincode/src/serde_compat/mod.rs
@@ -1,0 +1,102 @@
+//! Serde compatibility
+
+use {
+    crate::{
+        error::{ReadResult, WriteError, WriteResult},
+        io::{Reader, Writer},
+    },
+    core::{marker::PhantomData, mem::MaybeUninit},
+};
+
+mod de;
+mod ser;
+
+pub use {de::Deserializer, ser::Serializer};
+
+/// Wrapper struct that impls [`crate::SchemaRead`] and
+/// [`crate::SchemaWrite`] for types that impl [`serde::Deserialize`] and
+// [`serde::Serialize`], respectively.
+#[repr(transparent)]
+pub struct SerdeCompat<T> {
+    _marker: PhantomData<T>,
+}
+
+unsafe impl<'de, C, T> crate::SchemaRead<'de, C> for SerdeCompat<T>
+where
+    C: crate::config::Config,
+    T: serde::Deserialize<'de>,
+{
+    type Dst = T;
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let deserializer = Deserializer::<_, C>::new(reader);
+        let value = T::deserialize(deserializer)?;
+        dst.write(value);
+        Ok(())
+    }
+}
+
+unsafe impl<'de, C, T> crate::SchemaWrite<C> for SerdeCompat<T>
+where
+    C: crate::config::Config,
+    T: serde::Serialize,
+{
+    type Src = T;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        let mut serializer = ser::SizeOf::<C>::new();
+        serializer = src.serialize(serializer)?;
+        Ok(serializer.serialized_size())
+    }
+
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        let serializer = Serializer::<_, C>::new(writer);
+        src.serialize(serializer).map_err(WriteError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SerdeCompat;
+
+    #[test]
+    fn test_flattened_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+        #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
+        struct InnerMost<'a> {
+            #[serde(borrow)]
+            msg: &'a str,
+            #[serde(borrow)]
+            bytes: &'a [u8],
+        }
+        #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
+        struct InnerMore<'a> {
+            u32_value: u32,
+            #[serde(borrow)]
+            inner: InnerMost<'a>,
+        }
+        #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
+        struct Outer<'a> {
+            #[serde(borrow)]
+            inner: InnerMore<'a>,
+            bool_value: bool,
+        }
+
+        let value = Outer {
+            inner: InnerMore {
+                u32_value: 69_420,
+                inner: InnerMost {
+                    msg: "test msg",
+                    bytes: b"test bytes",
+                },
+            },
+            bool_value: true,
+        };
+        let value_serialized_bincode = bincode::serialize(&value)?;
+        let value_serialized_wincode = <SerdeCompat<Outer> as crate::Serialize>::serialize(&value)?;
+        assert_eq!(value_serialized_bincode, value_serialized_wincode);
+        let value_deserialized =
+            <SerdeCompat<Outer> as crate::Deserialize>::deserialize(&value_serialized_wincode)?;
+        assert_eq!(value_deserialized, value);
+        Ok(())
+    }
+}

--- a/wincode/src/serde_compat/ser.rs
+++ b/wincode/src/serde_compat/ser.rs
@@ -1,0 +1,821 @@
+//! Serializer
+
+use {
+    crate::{error::WriteError, io::Writer, SchemaWrite},
+    core::marker::PhantomData,
+    serde::Serialize,
+    thiserror::Error,
+};
+
+#[cfg(not(feature = "alloc"))]
+const CANNOT_COLLECT_STR: &str =
+    "`serde::Serializer::collect_str` got called but wincode was unable to allocate memory";
+
+const SEQUENCE_MUST_HAVE_LENGTH: &str =
+    "Serde provided wincode with a sequence without a length, which is not supported in wincode";
+
+const SERDE_ERROR: &str = "serde error";
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// [`serde::Serializer::collect_str`] got called but wincode was unable to allocate memory.
+    #[cfg(not(feature = "alloc"))]
+    #[error("{CANNOT_COLLECT_STR}")]
+    CannotCollectStr,
+    #[cfg(feature = "alloc")]
+    #[error("{msg}")]
+    CustomSerde { msg: alloc::string::String },
+    #[cfg(not(feature = "alloc"))]
+    #[error("{SERDE_ERROR}")]
+    CustomSerde,
+    /// Serde provided wincode with a sequence without a length, which is not
+    /// supported in wincode.
+    #[error("{SEQUENCE_MUST_HAVE_LENGTH}")]
+    SequenceMustHaveLength,
+    #[error(transparent)]
+    Write(#[from] WriteError),
+}
+
+impl From<Error> for WriteError {
+    fn from(err: Error) -> Self {
+        match err {
+            #[cfg(not(feature = "alloc"))]
+            Error::CannotCollectStr => Self::Custom(CANNOT_COLLECT_STR),
+            #[cfg(feature = "alloc")]
+            Error::CustomSerde { msg: _ } => Self::Custom(SERDE_ERROR),
+            #[cfg(not(feature = "alloc"))]
+            Error::CustomSerde => Self::Custom(SERDE_ERROR),
+            Error::SequenceMustHaveLength => Self::Custom(SEQUENCE_MUST_HAVE_LENGTH),
+            Error::Write(err) => err,
+        }
+    }
+}
+
+impl serde::ser::Error for Error {
+    #[cfg(feature = "alloc")]
+    fn custom<T>(msg: T) -> Self
+    where
+        T: core::fmt::Display,
+    {
+        Self::CustomSerde {
+            msg: alloc::string::ToString::to_string(&msg),
+        }
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn custom<T>(_msg: T) -> Self
+    where
+        T: core::fmt::Display,
+    {
+        Self::CustomSerde
+    }
+}
+
+pub struct Serializer<W, C = crate::config::Configuration> {
+    inner: W,
+    marker: PhantomData<C>,
+}
+
+impl<W, C> Serializer<W, C> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            inner: writer,
+            marker: PhantomData,
+        }
+    }
+
+    fn as_mut(&mut self) -> Serializer<&mut W, C> {
+        Serializer {
+            inner: &mut self.inner,
+            marker: self.marker,
+        }
+    }
+}
+
+macro_rules! impl_fn_serializer {
+    ($serialize_method:ident, $serialize_ty:ty) => {
+        fn $serialize_method(self, value: $serialize_ty) -> Result<Self::Ok, Self::Error> {
+            <$serialize_ty as SchemaWrite<C>>::write(self.inner, &value).map_err(Self::Error::Write)
+        }
+    };
+}
+
+impl<W, C> serde::Serializer for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    impl_fn_serializer!(serialize_bool, bool);
+    impl_fn_serializer!(serialize_i8, i8);
+    impl_fn_serializer!(serialize_i16, i16);
+    impl_fn_serializer!(serialize_i32, i32);
+    impl_fn_serializer!(serialize_i64, i64);
+    impl_fn_serializer!(serialize_u8, u8);
+    impl_fn_serializer!(serialize_u16, u16);
+    impl_fn_serializer!(serialize_u32, u32);
+    impl_fn_serializer!(serialize_u64, u64);
+    impl_fn_serializer!(serialize_f32, f32);
+    impl_fn_serializer!(serialize_f64, f64);
+    impl_fn_serializer!(serialize_char, char);
+    impl_fn_serializer!(serialize_str, &str);
+    impl_fn_serializer!(serialize_bytes, &[u8]);
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        <u8 as SchemaWrite<C>>::write(self.inner, &0u8).map_err(Self::Error::Write)
+    }
+
+    fn serialize_some<T>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        <u8 as SchemaWrite<C>>::write(&mut self.inner, &1u8)?;
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        <u32 as SchemaWrite<C>>::write(self.inner, &variant_index).map_err(Self::Error::Write)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        <u32 as SchemaWrite<C>>::write(&mut self.inner, &variant_index)?;
+        value.serialize(self)
+    }
+
+    fn serialize_seq(mut self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let len = len.ok_or(Self::Error::SequenceMustHaveLength)?;
+        <usize as SchemaWrite<C>>::write(&mut self.inner, &len)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        <u32 as SchemaWrite<C>>::write(&mut self.inner, &variant_index)?;
+        Ok(self)
+    }
+
+    fn serialize_map(mut self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        let len = len.ok_or(Self::Error::SequenceMustHaveLength)?;
+        <usize as SchemaWrite<C>>::write(&mut self.inner, &len)?;
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        <u32 as SchemaWrite<C>>::write(&mut self.inner, &variant_index)?;
+        Ok(self)
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn collect_str<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: core::fmt::Display + ?Sized,
+    {
+        Err(Self::Error::CannotCollectStr)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+impl<W, C> serde::ser::SerializeSeq for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W, C> serde::ser::SerializeTuple for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W, C> serde::ser::SerializeTupleStruct for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W, C> serde::ser::SerializeTupleVariant for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W, C> serde::ser::SerializeMap for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        key.serialize(self.as_mut())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W, C> serde::ser::SerializeStruct for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W, C> serde::ser::SerializeStructVariant for Serializer<W, C>
+where
+    C: crate::config::Config,
+    W: Writer,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self.as_mut())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+const SIZE_OVERFLOW: &str = "Overflow when calculating serialized size";
+
+#[derive(Debug, Error)]
+pub enum SizeOfError {
+    #[error(transparent)]
+    Serialize(Error),
+    /// Overflow when calculating serialized size
+    #[error("{SIZE_OVERFLOW}")]
+    SizeOverflow,
+}
+
+impl<E> From<E> for SizeOfError
+where
+    Error: From<E>,
+{
+    fn from(err: E) -> Self {
+        Self::Serialize(err.into())
+    }
+}
+
+impl From<SizeOfError> for WriteError {
+    fn from(err: SizeOfError) -> Self {
+        match err {
+            SizeOfError::Serialize(err) => err.into(),
+            SizeOfError::SizeOverflow => Self::Custom(SIZE_OVERFLOW),
+        }
+    }
+}
+
+impl serde::ser::Error for SizeOfError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: core::fmt::Display,
+    {
+        Self::Serialize(Error::custom(msg))
+    }
+}
+
+/// Dummy serializer used to compute serialized size
+#[repr(transparent)]
+pub(in crate::serde_compat) struct SizeOf<C> {
+    size: usize,
+    marker: PhantomData<C>,
+}
+
+impl<C> SizeOf<C> {
+    pub fn new() -> Self {
+        Self {
+            size: 0,
+            marker: PhantomData,
+        }
+    }
+
+    /// Returns the size in bytes that the serializer has already processed
+    pub fn serialized_size(&self) -> usize {
+        self.size
+    }
+
+    #[must_use]
+    fn add_size(&mut self, size: usize) -> Result<(), SizeOfError> {
+        self.size = self
+            .size
+            .checked_add(size)
+            .ok_or(SizeOfError::SizeOverflow)?;
+        Ok(())
+    }
+}
+
+macro_rules! impl_fn_sizeof {
+    ($serialize_method:ident, $serialize_ty:ty) => {
+        fn $serialize_method(mut self, value: $serialize_ty) -> Result<Self::Ok, Self::Error> {
+            let value_size = <$serialize_ty as SchemaWrite<C>>::size_of(&value)?;
+            self.add_size(value_size)?;
+            Ok(self)
+        }
+    };
+}
+
+impl<C> serde::Serializer for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    impl_fn_sizeof!(serialize_bool, bool);
+    impl_fn_sizeof!(serialize_i8, i8);
+    impl_fn_sizeof!(serialize_i16, i16);
+    impl_fn_sizeof!(serialize_i32, i32);
+    impl_fn_sizeof!(serialize_i64, i64);
+    impl_fn_sizeof!(serialize_i128, i128);
+    impl_fn_sizeof!(serialize_u8, u8);
+    impl_fn_sizeof!(serialize_u16, u16);
+    impl_fn_sizeof!(serialize_u32, u32);
+    impl_fn_sizeof!(serialize_u64, u64);
+    impl_fn_sizeof!(serialize_u128, u128);
+    impl_fn_sizeof!(serialize_f32, f32);
+    impl_fn_sizeof!(serialize_f64, f64);
+    impl_fn_sizeof!(serialize_char, char);
+    impl_fn_sizeof!(serialize_str, &str);
+    impl_fn_sizeof!(serialize_bytes, &[u8]);
+
+    fn serialize_none(mut self) -> Result<Self::Ok, Self::Error> {
+        let discriminant_size = <u8 as SchemaWrite<C>>::size_of(&0u8)?;
+        self.add_size(discriminant_size)?;
+        Ok(self)
+    }
+
+    fn serialize_some<T>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let discriminant_size = <u8 as SchemaWrite<C>>::size_of(&1u8)?;
+        self.add_size(discriminant_size)?;
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_unit_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        let variant_index_size = <u32 as SchemaWrite<C>>::size_of(&variant_index)?;
+        self.add_size(variant_index_size)?;
+        Ok(self)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let variant_index_size = <u32 as SchemaWrite<C>>::size_of(&variant_index)?;
+        self.add_size(variant_index_size)?;
+        value.serialize(self)
+    }
+
+    fn serialize_seq(mut self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let len = len.ok_or(Error::SequenceMustHaveLength)?;
+        let len_size = <usize as SchemaWrite<C>>::size_of(&len)?;
+        self.add_size(len_size)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        let variant_index_size = <u32 as SchemaWrite<C>>::size_of(&variant_index)?;
+        self.add_size(variant_index_size)?;
+        Ok(self)
+    }
+
+    fn serialize_map(mut self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        let len = len.ok_or(Error::SequenceMustHaveLength)?;
+        let len_size = <usize as SchemaWrite<C>>::size_of(&len)?;
+        self.add_size(len_size)?;
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        let variant_index_size = <u32 as SchemaWrite<C>>::size_of(&variant_index)?;
+        self.add_size(variant_index_size)?;
+        Ok(self)
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn collect_str<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: core::fmt::Display + ?Sized,
+    {
+        Err(Error::CannotCollectStr.into())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+impl<C> serde::ser::SerializeSeq for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<C> serde::ser::SerializeTuple for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<C> serde::ser::SerializeTupleStruct for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<C> serde::ser::SerializeTupleVariant for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<C> serde::ser::SerializeMap for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = key.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<C> serde::ser::SerializeStruct for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<C> serde::ser::SerializeStructVariant for SizeOf<C>
+where
+    C: crate::config::Config,
+{
+    type Ok = Self;
+    type Error = SizeOfError;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let serializer = SizeOf {
+            size: self.size,
+            marker: self.marker,
+        };
+        *self = value.serialize(serializer)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+}


### PR DESCRIPTION
This PR adds optional support for serde compatibility, which was [available in bincode](https://docs.rs/bincode/2.0.0/bincode/serde/index.html).
The serde compatibility wrapper, deserializer, and serializer should function identically to their counterparts in `bincode`.