### PR TITLE
Add fallback for as_trusted_for calls

### DIFF
--- a/wincode/src/io/mod.rs
+++ b/wincode/src/io/mod.rs
@@ -16,6 +16,8 @@ pub enum ReadError {
         "Unsupported zero-copy operation: reader does not support deserializing zero-copy types"
     )]
     UnsupportedZeroCopy,
+    #[error("requested trusted size exceeds available {0} bytes")]
+    TrustedSizeAvailableLimit(usize),
     #[cfg(feature = "std")]
     #[error(transparent)]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
Callers of `as_trusted_for` should handle cases where `Reader` implementation isn't able to provide full buffer of desired size immediately. They should fallback to not using trusted reader in that case (slower, but still functional path).

Current API is almost ready for this pattern, since `as_trusted_for` returns a `Result` and its documentation kind of imply that if reader cannot satisfy the request, it should return error. However falling back to different way of reading for all errors could be wrond, since some errors are logic errors or underlying IO errors, which should cause immediate break and propagating errors up.
For this purpose special `ReadError` variant is introduced to mark recoverable error for too large `as_trusted_for` request.

Additionally it's imaginable that readers would be able to fulfill a smaller request for trusted reader and caller could adjust the request to still avoid bounds for whatever buffer space is available in the reader. Thus the recoverable error contains `usize` with the limit of currently available "trusted bytes" in case caller wants to loop and pick fast / slow path depending on such size.