### PR TITLE
chore: pin nightly version to avoid flaky build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-02-01
-          components: rustfmt, miri
+          toolchain: nightly-2024-11-23
+          components: rustfmt, miri, rust-src
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - name: rustfmt (check)
-        run: cargo +nightly-2026-02-01 fmt --all -- --check
+        run: cargo +nightly-2024-11-23 fmt --all -- --check
       - name: miri (check)
-        run: cargo +nightly-2026-02-01 miri test --all-features --lib --bins --no-fail-fast --workspace --exclude wincode-fuzz
+        run: cargo +nightly-2024-11-23 miri test --all-features --lib --bins --no-fail-fast --workspace --exclude wincode-fuzz
 
   lint-test:
     name: clippy & tests (MSRV)


### PR DESCRIPTION
It seems the latest version of nightly broke miri. Pinning our nightly version for the miri suite to a known working version to avoid inconsistent builds.