### PR TITLE
feat: add take_array replacing all usages of fill_array

### DIFF
--- a/wincode/src/io/mod.rs
+++ b/wincode/src/io/mod.rs
@@ -77,6 +77,16 @@ pub trait Reader<'a> {
         Ok(unsafe { &*src.as_ptr().cast::<[u8; N]>() })
     }
 
+    /// Return exactly `N` bytes as `[u8; N]` and advance by `N`.
+    ///
+    /// Errors if fewer than `N` bytes are available.
+    #[inline]
+    fn take_array<const N: usize>(&mut self) -> ReadResult<[u8; N]> {
+        let arr = *self.fill_array::<N>()?;
+        unsafe { self.consume_unchecked(N) }
+        Ok(arr)
+    }
+
     /// Zero-copy: return a borrowed slice of exactly `len` bytes and advance by `len`.
     ///
     /// The returned slice is tied to `'a`. Prefer [`Reader::fill_exact`] unless you truly need zero-copy.
@@ -275,6 +285,11 @@ impl<'a, R: Reader<'a> + ?Sized> Reader<'a> for &mut R {
     #[inline(always)]
     fn fill_array<const N: usize>(&mut self) -> ReadResult<&[u8; N]> {
         (*self).fill_array()
+    }
+
+    #[inline(always)]
+    fn take_array<const N: usize>(&mut self) -> ReadResult<[u8; N]> {
+        (*self).take_array()
     }
 
     #[inline(always)]

--- a/wincode/src/len.rs
+++ b/wincode/src/len.rs
@@ -258,13 +258,11 @@ macro_rules! impl_fix_int {
             #[inline(always)]
             #[allow(irrefutable_let_patterns)]
             fn read<'de>(mut reader: impl Reader<'de>) -> ReadResult<usize> {
-                let bytes = reader.fill_array::<{ size_of::<$type>() }>()?;
+                let bytes = reader.take_array::<{ size_of::<$type>() }>()?;
                 let len = match C::ByteOrder::ENDIAN {
-                    Endian::Big => <$type>::from_be_bytes(*bytes),
-                    Endian::Little => <$type>::from_le_bytes(*bytes),
+                    Endian::Big => <$type>::from_be_bytes(bytes),
+                    Endian::Little => <$type>::from_le_bytes(bytes),
                 };
-                // SAFETY: `fill_array` ensures we read exactly `size_of::<$type>()` bytes.
-                unsafe { reader.consume_unchecked(size_of::<$type>()) };
                 let Ok(len) = usize::try_from(len) else {
                     return Err(pointer_sized_decode_error());
                 };

--- a/wincode/src/schema/external/uuid.rs
+++ b/wincode/src/schema/external/uuid.rs
@@ -36,9 +36,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for Uuid {
                 return Err(crate::error::invalid_value("Uuid: invalid length prefix"));
             }
         }
-        let bytes = *reader.fill_array::<{ size_of::<Uuid>() }>()?;
-        // SAFETY: `fill_array` guarantees we get exactly `size_of::<Uuid>()` bytes.
-        unsafe { reader.consume_unchecked(size_of::<Uuid>()) };
+        let bytes = reader.take_array::<{ size_of::<Uuid>() }>()?;
         // SAFETY: `Uuid` is a `#[repr(transparent)]` newtype over `uuid::Bytes` (`[u8; 16]`).
         let dst =
             unsafe { transmute::<&mut MaybeUninit<Uuid>, &mut MaybeUninit<uuid::Bytes>>(dst) };

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -163,9 +163,7 @@ macro_rules! impl_float {
 
                 #[inline(always)]
                 fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-                    let bytes = *reader.fill_array::<{ size_of::<$ty>() }>()?;
-                    // SAFETY: fill_array is guaranteed to consume `size_of::<$ty>()` bytes.
-                    unsafe { reader.consume_unchecked(size_of::<$ty>()) };
+                    let bytes = reader.take_array::<{ size_of::<$ty>() }>()?;
                     let val = match C::ByteOrder::ENDIAN {
                         Endian::Big => <$ty>::from_be_bytes(bytes),
                         Endian::Little => <$ty>::from_le_bytes(bytes),
@@ -272,9 +270,7 @@ macro_rules! impl_byte {
                     mut reader: impl Reader<'de>,
                     dst: &mut MaybeUninit<Self::Dst>,
                 ) -> ReadResult<()> {
-                    let byte = *reader.fill_array::<{ 1 }>()?;
-                    // SAFETY: `fill_array` guarantees we get one byte.
-                    unsafe { reader.consume_unchecked(1) };
+                    let byte = reader.take_array::<{ 1 }>()?;
                     dst.write(byte[0] as $type);
                     Ok(())
                 }
@@ -1669,9 +1665,7 @@ unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for Ipv4Addr {
 
     #[inline]
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let bytes = *reader.fill_array::<4>()?;
-        // SAFETY: `fill_array` guarantees 4 bytes are available
-        unsafe { reader.consume_unchecked(4) };
+        let bytes = reader.take_array::<4>()?;
         dst.write(Ipv4Addr::from(bytes));
         Ok(())
     }
@@ -1707,9 +1701,7 @@ unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for Ipv6Addr {
 
     #[inline]
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let bytes = *reader.fill_array::<16>()?;
-        // SAFETY: `fill_array` guarantees 16 bytes are available
-        unsafe { reader.consume_unchecked(16) };
+        let bytes = reader.take_array::<16>()?;
         dst.write(Ipv6Addr::from(bytes));
         Ok(())
     }

--- a/wincode/src/schema/int_encoding.rs
+++ b/wincode/src/schema/int_encoding.rs
@@ -80,9 +80,7 @@ macro_rules! impl_fix_int {
 
                 #[inline(always)]
                 fn [<decode_ $ty>] <'de>(mut reader: impl Reader<'de>) -> ReadResult<$ty> {
-                    let bytes = *reader.fill_array::<{ size_of::<$ty>() }>()?;
-                    // SAFETY: fill_array is guaranteed to consume `size_of::<$ty>()` bytes.
-                    unsafe { reader.consume_unchecked(size_of::<$ty>()) };
+                    let bytes = reader.take_array::<{ size_of::<$ty>() }>()?;
 
                     let val = match <$byte_order>::ENDIAN {
                         Endian::Big => <$ty>::from_be_bytes(bytes),


### PR DESCRIPTION
All uses of `Reader::fill_array` boil down to
```rust
let bytes: [u8; N] = *reader.fill_array();
unsafe { reader.consume_unchecked(N) };
```
which suggests this API isn't in its proper shape.
Additionally it forces implementation to always have `N` consecutive memory bytes possible to borrow, which makes it difficult to implement buffered reader.

`take_array`, which reads directly into stack created array and returns it, is a direct replacement for all uses of `fill_array` in `wincode` repository. Right now it's just a wrapper over `fill_array` and `consume_unchecked`.

Changes:
* add `take_array`
* replace `fill_array + consume_unchecked` with `take_array` 