### PR TITLE
chore: don't deny warnings during compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ manual_let_else = "deny"
 used_underscore_binding = "deny"
 arithmetic_side_effects = "deny"
 
-[workspace.lints.rust]
-warnings = "deny"
-
 [workspace.package]
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/wincode"


### PR DESCRIPTION
We shouldn't treat warnings as errors during regular compilation, since it just slows down development, during which temporary broken or unused code is acceptable.
We should only deny it from being merged into main repository, for that CI check is sufficient (and it's already configured this way).

Remove deny warnings from `Cargo.toml`.

This follows similar change that was done in `agave`: https://github.com/anza-xyz/agave/pull/9269