### PR TITLE
fix: update imports and cfg for no-alloc compilation

### DIFF
--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -64,7 +64,11 @@ use {
         io::{Reader, Writer},
         schema::{SchemaRead, SchemaWrite},
     },
-    core::{marker::PhantomData, mem::MaybeUninit, ptr},
+    core::{
+        marker::PhantomData,
+        mem::{self, MaybeUninit},
+        ptr,
+    },
 };
 #[cfg(feature = "alloc")]
 use {
@@ -75,7 +79,6 @@ use {
         },
     },
     alloc::{boxed::Box as AllocBox, collections, rc::Rc as AllocRc, sync::Arc as AllocArc, vec},
-    core::mem,
 };
 
 /// A [`Vec`](std::vec::Vec) with a customizable length encoding.

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -23,7 +23,7 @@ use {
     },
     core::{
         marker::PhantomData,
-        mem::{self, MaybeUninit, transmute},
+        mem::{MaybeUninit, transmute},
         net::{IpAddr, Ipv4Addr, Ipv6Addr},
         num::{
             NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
@@ -49,6 +49,7 @@ use {
         sync::Arc,
         vec::Vec,
     },
+    core::mem,
 };
 
 macro_rules! impl_int_config_dependent {

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -440,6 +440,7 @@ where
 }
 
 #[inline(always)]
+#[cfg(feature = "alloc")]
 fn write_elem_iter_prealloc_check<'a, T, Len, C>(
     writer: impl Writer,
     src: impl ExactSizeIterator<Item = &'a T::Src>,
@@ -484,6 +485,7 @@ where
 }
 
 #[inline(always)]
+#[cfg(feature = "alloc")]
 fn write_elem_slice_prealloc_check<T, Len, C>(
     writer: impl Writer,
     src: &[T::Src],


### PR DESCRIPTION
`cargo test --no-default-features` fails to compile due to lacking import of core::mem when alloc feature is disabled.

Also warnings are reported for some functions and import when compiling without alloc feature.
