### PR TITLE
feat(io): add advance function to Reader

### DIFF
--- a/wincode/src/io/mod.rs
+++ b/wincode/src/io/mod.rs
@@ -171,6 +171,18 @@ pub trait Reader<'a> {
         Err(ReadError::UnsupportedBorrow(BorrowKind::CallSite))
     }
 
+    /// Advance the reader by `n_bytes`, discarding those bytes.
+    ///
+    /// Use this to skip over bytes that are no longer needed — for example, when handling a legacy
+    /// serialized format where a field is still present in the binary representation but its value
+    /// is ignored for compatibility reasons.
+    ///
+    /// Errors if fewer than `n_bytes` bytes are available.
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        self.take_scoped(n_bytes).map(|_| ())
+    }
+
     /// Advance the parent by `n_bytes` and return a [`Reader`] that can elide bounds checks within
     /// that `n_bytes` window.
     ///
@@ -313,6 +325,11 @@ impl<'a, R: Reader<'a> + ?Sized> Reader<'a> for &mut R {
     #[inline(always)]
     unsafe fn as_trusted_for(&mut self, n_bytes: usize) -> ReadResult<impl Reader<'a>> {
         unsafe { (*self).as_trusted_for(n_bytes) }
+    }
+
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        (*self).advance(n_bytes)
     }
 
     #[inline(always)]

--- a/wincode/src/io/slice.rs
+++ b/wincode/src/io/slice.rs
@@ -615,8 +615,13 @@ mod tests {
                 });
             } else {
                 with_untrusted_readers!(&bytes, |reader| {
-                    prop_assert!(matches!(reader.advance(skip), Err(ReadError::ReadSizeLimit(x)) if x == skip));
+                    prop_assert!(matches!(reader.advance(skip), Err(ReadError::ReadSizeLimit(x)) if x <= skip));
                 });
+                #[cfg(feature = "std")]
+                {
+                    let mut reader = std::io::BufReader::new(bytes.as_slice());
+                    prop_assert!(matches!(reader.advance(skip), Err(ReadError::ReadSizeLimit(x)) if x <= skip));
+                }
             }
         }
 

--- a/wincode/src/io/slice.rs
+++ b/wincode/src/io/slice.rs
@@ -603,6 +603,24 @@ mod tests {
         }
 
         #[test]
+        fn test_reader_advance(
+            bytes in proptest::collection::vec(any::<u8>(), 0..=64usize),
+            skip in 0..=64usize
+        ) {
+            if skip <= bytes.len() {
+                with_readers!(&bytes, |reader| {
+                    reader.advance(skip).unwrap();
+                    let rest = reader.take_scoped(bytes.len() - skip).unwrap();
+                    prop_assert_eq!(rest, &bytes[skip..]);
+                });
+            } else {
+                with_untrusted_readers!(&bytes, |reader| {
+                    prop_assert!(matches!(reader.advance(skip), Err(ReadError::ReadSizeLimit(x)) if x == skip));
+                });
+            }
+        }
+
+        #[test]
         fn test_reader_copy_into_t(ints in proptest::collection::vec(any::<u64>(), 0..=100)) {
             let bytes = ints.iter().flat_map(|int| int.to_le_bytes()).collect::<Vec<u8>>();
             with_readers!(&bytes, |reader| {

--- a/wincode/src/io/slice.rs
+++ b/wincode/src/io/slice.rs
@@ -110,6 +110,14 @@ impl<'a> Reader<'a> for SliceUnchecked<'a, u8> {
     fn take_scoped(&mut self, len: usize) -> ReadResult<&[u8]> {
         self.take_borrowed(len)
     }
+
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        // SAFETY: by constructing `SliceUnchecked`, caller guarantees
+        // they will read within the bounds of the slice.
+        unsafe { advance_slice_unchecked(&mut self.buf, n_bytes) };
+        Ok(())
+    }
 }
 
 /// Implementation of [`Reader`] and [`Writer`] over a slice that does not perform any bounds checks.
@@ -198,6 +206,14 @@ impl<'a> Reader<'a> for SliceMutUnchecked<'a, u8> {
     fn take_scoped(&mut self, len: usize) -> ReadResult<&[u8]> {
         self.take_borrowed(len)
     }
+
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        // SAFETY: by constructing `SliceMutUnchecked`, caller guarantees
+        // they will read within the bounds of the slice.
+        unsafe { advance_slice_mut_unchecked(&mut self.buf, n_bytes) };
+        Ok(())
+    }
 }
 
 /// Implementation of [`Reader`] over a slice that does not perform any bounds checks.
@@ -243,6 +259,11 @@ impl<'a> Reader<'a> for SliceScopedUnchecked<'a, '_, u8> {
     fn take_scoped(&mut self, len: usize) -> ReadResult<&[u8]> {
         self.inner.take_scoped(len)
     }
+
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        self.inner.advance(n_bytes)
+    }
 }
 
 impl<'a> Reader<'a> for &'a [u8] {
@@ -281,6 +302,14 @@ impl<'a> Reader<'a> for &'a [u8] {
         };
         *self = rest;
         Ok(*src)
+    }
+
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        if advance_slice_checked(self, n_bytes).is_none() {
+            return Err(read_size_limit(n_bytes));
+        }
+        Ok(())
     }
 
     #[inline(always)]
@@ -343,6 +372,14 @@ impl<'a> Reader<'a> for &'a mut [u8] {
         };
         *self = rest;
         Ok(*src)
+    }
+
+    #[inline(always)]
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        if advance_slice_mut_checked(self, n_bytes).is_none() {
+            return Err(read_size_limit(n_bytes));
+        }
+        Ok(())
     }
 }
 

--- a/wincode/src/io/std_read.rs
+++ b/wincode/src/io/std_read.rs
@@ -79,17 +79,18 @@ impl<R: Read + ?Sized> Reader<'_> for BufReader<R> {
 
     fn advance(&mut self, mut n_bytes: usize) -> ReadResult<()> {
         use io::BufRead as _;
-        loop {
-            let buffered = self.buffer().len();
-            if let Some(remaining) = n_bytes.checked_sub(buffered) {
-                self.consume(buffered);
+        while n_bytes != 0 {
+            let buf_len = loop {
+                match self.fill_buf() {
+                    Ok(buf) => break buf.len(),
+                    Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(e) => return Err(e.into()),
+                }
+            };
+
+            if let Some(remaining) = n_bytes.checked_sub(buf_len) {
+                self.consume(buf_len);
                 n_bytes = remaining;
-                if n_bytes == 0 {
-                    break;
-                }
-                if self.fill_buf()?.is_empty() {
-                    return Err(read_size_limit(n_bytes));
-                }
             } else {
                 self.consume(n_bytes);
                 break;

--- a/wincode/src/io/std_read.rs
+++ b/wincode/src/io/std_read.rs
@@ -60,12 +60,42 @@ impl<R: Read + ?Sized> Reader<'_> for ReadAdapter<R> {
     fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
         copy_into_slice(&mut self.0, dst)
     }
+
+    fn advance(&mut self, mut n_bytes: usize) -> ReadResult<()> {
+        let mut buf = [MaybeUninit::<u8>::uninit(); 64];
+        while let Some(remaining) = n_bytes.checked_sub(buf.len()) {
+            copy_into_slice(&mut self.0, &mut buf)?;
+            n_bytes = remaining;
+        }
+        copy_into_slice(&mut self.0, &mut buf[..n_bytes])
+    }
 }
 
 impl<R: Read + ?Sized> Reader<'_> for BufReader<R> {
     #[inline(always)]
     fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
         copy_into_slice(self, dst)
+    }
+
+    fn advance(&mut self, mut n_bytes: usize) -> ReadResult<()> {
+        use io::BufRead as _;
+        loop {
+            let buffered = self.buffer().len();
+            if let Some(remaining) = n_bytes.checked_sub(buffered) {
+                self.consume(buffered);
+                n_bytes = remaining;
+                if n_bytes == 0 {
+                    break;
+                }
+                if self.fill_buf()?.is_empty() {
+                    return Err(read_size_limit(n_bytes));
+                }
+            } else {
+                self.consume(n_bytes);
+                break;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/wincode/src/io/std_read.rs
+++ b/wincode/src/io/std_read.rs
@@ -82,6 +82,7 @@ impl<R: Read + ?Sized> Reader<'_> for BufReader<R> {
         while n_bytes != 0 {
             let buf_len = loop {
                 match self.fill_buf() {
+                    Ok([]) => return Err(read_size_limit(n_bytes)),
                     Ok(buf) => break buf.len(),
                     Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
                     Err(e) => return Err(e.into()),

--- a/wincode/src/io/test_util.rs
+++ b/wincode/src/io/test_util.rs
@@ -21,4 +21,8 @@ impl Reader<'_> for NoBorrowReader<'_> {
     fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
         self.inner.copy_into_slice(dst)
     }
+
+    fn advance(&mut self, n_bytes: usize) -> ReadResult<()> {
+        self.inner.advance(n_bytes)
+    }
 }


### PR DESCRIPTION
Handling legacy binary formats occasionally require skipping over a number of bytes when reading serialized data.
Two such cases the came up recently are:
* trailing bytes encountered deserializing `solana_ledger::BitVec` (https://github.com/anza-xyz/agave/pull/11624/)
* delegations in `EpochStakes` (https://github.com/anza-xyz/agave/pull/11758/)

This PR adds `advance` function, which can be used to discard a number of input bytes without inspecting them. By default it's implemented with `take_scoped()`, which limits it to readers supporting such call - `std::io::Read` implementations, which do not support `take_scoped` have a more expensive dedicated `advance` implementation that iterate copying input buffer or using `consume` in `BufReader`.