### PR TITLE
feat(derive): support custom wincode crate path

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -490,9 +490,11 @@ pub(crate) fn suppress_unused_fields(args: &SchemaArgs) -> TokenStream {
     }
 }
 
-/// Get the path to `wincode` based on the `internal` flag.
+/// Get the path to `wincode` based on the `internal` or `crate_path` option.
 pub(crate) fn get_crate_name(args: &SchemaArgs) -> Path {
-    if args.internal {
+    if let Some(crate_path) = &args.crate_path {
+        crate_path.clone()
+    } else if args.internal {
         parse_quote!(crate)
     } else {
         parse_quote!(::wincode)
@@ -571,6 +573,12 @@ pub(crate) struct SchemaArgs {
     /// - `#[wincode(assert_zero_copy(MyConfig))]` - uses custom config path
     #[darling(default)]
     pub(crate) assert_zero_copy: Option<AssertZeroCopyConfig>,
+    /// Specifies the path to the `wincode` crate.
+    ///
+    /// Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module.
+    /// The path is emitted as written and resolved from the derive expansion site.
+    #[darling(rename = "crate", default)]
+    pub(crate) crate_path: Option<Path>,
 }
 
 /// Configuration for zero-copy assertions.

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -334,6 +334,7 @@
 //! |`struct_extensions` (DEPRECATED)|`bool`|`false`|Generates placement initialization helpers on `SchemaRead` struct implementations. DEPRECATED; Use `#[derive(UninitBuilder)]` instead.|
 //! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
 //! |`assert_zero_copy`|`bool`\|`Path`|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. Can specify a custom config path, will use the [`DefaultConfig`](config::DefaultConfig) if `bool` form is used.|
+//! |`crate`|`Path`|`::wincode`|Specifies the path to the `wincode` crate. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module. The path is emitted as written and resolved from the derive expansion site.|
 //!
 //! ### `no_suppress_unused`
 //!

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -4634,4 +4634,19 @@ mod tests {
             prop_assert_eq!(value, deserialized);
         });
     }
+
+    #[test]
+    fn test_external_wincode() {
+        use crate as my_wincode;
+        #[derive(SchemaRead, SchemaWrite, Debug, PartialEq)]
+        #[wincode(crate = "my_wincode")]
+        struct Foo {
+            bar: u8,
+        }
+
+        let data = Foo { bar: 42 };
+        let serialized = serialize(&data).unwrap();
+        let deserialized: Foo = deserialize(&serialized).unwrap();
+        assert_eq!(data, deserialized);
+    }
 }


### PR DESCRIPTION
Allows specifying a custom `wincode` path for the derive macros. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module.
```rs
#[derive(SchemaRead, SchemaWrite)]
#[wincode(crate = "path::to::wincode")]
struct Foo {
    a: u8
}
```
Fixes #298