### PR TITLE
fix(io): ensure Vec<u8> and Cursor<Vec<u8>> don't expose uninit mem

### DIFF
--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -374,18 +374,18 @@ pub(super) mod vec {
         // SAFETY: by calling `as_trusted_for`, caller guarantees they
         // will fully initialize `n_bytes` of memory and will not write
         // beyond the bounds of the slice.
-        Ok(unsafe { CursorVecUnchecked::new(inner, pos) })
+        Ok(unsafe { VecPosUnchecked::new(inner, pos) })
     }
 }
 
 #[cfg(feature = "alloc")]
-struct CursorVecUnchecked<'a> {
+struct VecPosUnchecked<'a> {
     inner: &'a mut Vec<u8>,
     pos: &'a mut usize,
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> CursorVecUnchecked<'a> {
+impl<'a> VecPosUnchecked<'a> {
     /// # Safety
     ///
     /// The caller must ensure that `*pos` is within `inner`'s capacity and
@@ -398,7 +398,7 @@ impl<'a> CursorVecUnchecked<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> Writer for CursorVecUnchecked<'a> {
+impl<'a> Writer for VecPosUnchecked<'a> {
     #[inline]
     fn write(&mut self, src: &[u8]) -> WriteResult<()> {
         // SAFETY:

--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -290,6 +290,35 @@ mod vec {
         Ok(())
     }
 
+    /// Zero-fill the gap between `inner.len()` and `pos`, if `pos` is past the
+    /// current initialized length.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner.capacity() >= pos`.
+    ///
+    /// If `pos > inner.len()`, the range `inner.len()..pos` must be spare capacity
+    /// owned by `inner` and valid to write as `MaybeUninit<u8>`. This function
+    /// initializes that entire gap with zero bytes and then sets `inner.len()` to
+    /// `pos`.
+    ///
+    /// Callers should normally establish this by calling `maybe_grow(inner, pos, n)`
+    /// with any `n` such that `pos + n` is checked and fits in the vector capacity.
+    #[inline]
+    unsafe fn zero_fill_gap(inner: &mut Vec<u8>, pos: usize) {
+        if let Some(init_gap) = pos.checked_sub(inner.len()) {
+            let spare = inner.spare_capacity_mut();
+            debug_assert!(spare.len() >= init_gap);
+
+            unsafe {
+                spare
+                    .get_unchecked_mut(..init_gap)
+                    .fill(MaybeUninit::new(0));
+                inner.set_len(pos);
+            }
+        }
+    }
+
     /// Add `len` to the cursor's position and update the length of the vector if necessary.
     ///
     /// # SAFETY:
@@ -311,43 +340,90 @@ mod vec {
     /// Write `src` to the vector at the current position and advance the position by `src.len()`.
     pub(super) fn write(inner: &mut Vec<u8>, pos: &mut usize, src: &[u8]) -> WriteResult<()> {
         maybe_grow(inner, *pos, src.len())?;
-        // SAFETY: We just ensured at least `pos + src.len()` capacity is available.
+        // SAFETY: `maybe_grow` checked `*pos + src.len()` and ensured capacity
+        // for it, so `inner.capacity() >= *pos`; `zero_fill_gap` only writes
+        // `inner.len()..*pos`.
+        unsafe { zero_fill_gap(inner, *pos) };
+        // SAFETY: `maybe_grow` ensured at least `*pos + src.len()` capacity is
+        // available.
         unsafe { ptr::copy_nonoverlapping(src.as_ptr(), inner.as_mut_ptr().add(*pos), src.len()) };
-        // SAFETY: We just wrote `src.len()` bytes to the vector.
+        // SAFETY: `zero_fill_gap` initialized any gap before `*pos`, and we
+        // just wrote `src.len()` bytes starting at `*pos`.
         unsafe { add_len(inner, pos, src.len()) };
         Ok(())
     }
 
     #[inline]
-    #[expect(clippy::arithmetic_side_effects)]
     pub(super) unsafe fn as_trusted_for<'a>(
         inner: &'a mut Vec<u8>,
         pos: &'a mut usize,
         n_bytes: usize,
     ) -> WriteResult<impl Writer> {
         maybe_grow(inner, *pos, n_bytes)?;
-        // SAFETY: `maybe_grow` ensures at least `pos + n_bytes` capacity is available.
-        let buf = unsafe {
-            from_raw_parts_mut(
-                inner.as_mut_ptr().add(*pos).cast::<MaybeUninit<u8>>(),
-                n_bytes,
-            )
-        };
-
-        *pos += n_bytes;
+        // SAFETY: `maybe_grow` checked `*pos + n_bytes` and ensured capacity
+        // for it, so `inner.capacity() >= *pos`; `zero_fill_gap` only writes
+        // `inner.len()..*pos`.
+        unsafe { zero_fill_gap(inner, *pos) };
         // SAFETY: by calling `as_trusted_for`, caller guarantees they
         // will fully initialize `n_bytes` of memory and will not write
         // beyond the bounds of the slice.
-        Ok(unsafe { SliceMutUnchecked::new(buf) })
+        Ok(unsafe { CursorVecUnchecked::new(inner, pos) })
     }
+}
 
+#[cfg(feature = "alloc")]
+struct CursorVecUnchecked<'a> {
+    inner: &'a mut Vec<u8>,
+    pos: &'a mut usize,
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> CursorVecUnchecked<'a> {
+    /// # Safety
+    ///
+    /// The caller must ensure that `*pos` is within `inner`'s capacity and
+    /// that any gap before `*pos` has already been initialized. Writes through
+    /// this unchecked writer must stay within the trusted window reserved by
+    /// the caller.
+    const unsafe fn new(inner: &'a mut Vec<u8>, pos: &'a mut usize) -> Self {
+        Self { inner, pos }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> Writer for CursorVecUnchecked<'a> {
     #[inline]
-    pub(super) fn finish(inner: &mut Vec<u8>, pos: usize) {
-        if pos > inner.len() {
-            unsafe {
-                inner.set_len(pos);
-            }
+    fn write(&mut self, src: &[u8]) -> WriteResult<()> {
+        let cur_len = self.inner.len();
+        let cur_pos = *self.pos;
+        #[expect(clippy::arithmetic_side_effects)]
+        let next_pos = cur_pos + src.len();
+
+        // SAFETY:
+        // - `as_trusted_for` ensured sufficient capacity for the trusted window before
+        //   constructing this writer.
+        // - The trusted-writer contract requires all writes through this writer to stay
+        //   within that reserved window.
+        // - Given Rust's aliasing rules, we can assume that `src` does not overlap with
+        //   the internal buffer.
+        unsafe {
+            copy_nonoverlapping(
+                src.as_ptr(),
+                self.inner.as_mut_ptr().add(cur_pos),
+                src.len(),
+            );
         }
+
+        if next_pos > cur_len {
+            // SAFETY: any gap before the trusted window was initialized before
+            // constructing this writer, and this call just initialized the bytes
+            // from the previous cursor position through `next_pos`.
+            unsafe { self.inner.set_len(next_pos) }
+        }
+
+        *self.pos = next_pos;
+
+        Ok(())
     }
 }
 
@@ -386,12 +462,6 @@ impl Writer for Cursor<&mut Vec<u8>> {
         vec::write(self.inner, &mut self.pos, src)
     }
 
-    #[inline]
-    fn finish(&mut self) -> WriteResult<()> {
-        vec::finish(self.inner, self.pos);
-        Ok(())
-    }
-
     #[inline(always)]
     unsafe fn as_trusted_for(&mut self, n_bytes: usize) -> WriteResult<impl Writer> {
         unsafe { vec::as_trusted_for(self.inner, &mut self.pos, n_bytes) }
@@ -428,12 +498,6 @@ impl Writer for Cursor<Vec<u8>> {
     #[inline]
     fn write(&mut self, src: &[u8]) -> WriteResult<()> {
         vec::write(&mut self.inner, &mut self.pos, src)
-    }
-
-    #[inline]
-    fn finish(&mut self) -> WriteResult<()> {
-        vec::finish(&mut self.inner, self.pos);
-        Ok(())
     }
 
     #[inline(always)]
@@ -631,5 +695,38 @@ mod tests {
                 prop_assert_eq!(&deserialized[i].zero_copy_content, chunk);
             }
         }
+    }
+
+    #[test]
+    fn cursor_vec_write_zero_fills_gap() {
+        let mut output = vec![1, 2, 3];
+        let mut cursor = Cursor::new_at(&mut output, 6);
+
+        cursor.write(&[9, 10]).unwrap();
+
+        assert_eq!(output, vec![1, 2, 3, 0, 0, 0, 9, 10]);
+    }
+
+    #[test]
+    fn cursor_vec_trusted_write_zero_fills_gap() {
+        let mut output = vec![1, 2, 3];
+        let mut cursor = Cursor::new_at(&mut output, 6);
+
+        unsafe { <Cursor<_> as Writer>::as_trusted_for(&mut cursor, 2) }
+            .unwrap()
+            .write(&[9, 10])
+            .unwrap();
+
+        assert_eq!(output, vec![1, 2, 3, 0, 0, 0, 9, 10]);
+    }
+
+    #[test]
+    fn cursor_vec_finish_does_not_extend_len() {
+        let mut output = Vec::with_capacity(8);
+        let mut cursor = Cursor::new_at(&mut output, 6);
+
+        cursor.finish().unwrap();
+
+        assert_eq!(output.len(), 0);
     }
 }

--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -259,7 +259,7 @@ impl<const N: usize> Writer for Cursor<&mut MaybeUninit<[u8; N]>> {
 
 /// Helper functions for writing to `Cursor<&mut Vec<u8>>` and `Cursor<Vec<u8>>`.
 #[cfg(feature = "alloc")]
-mod vec {
+pub(super) mod vec {
     use super::*;
 
     /// Grow the vector if necessary to accommodate the given `needed` bytes.
@@ -273,7 +273,7 @@ mod vec {
     ///
     /// Panics if the new capacity exceeds `isize::MAX` _bytes_.
     #[inline]
-    pub(super) fn maybe_grow(inner: &mut Vec<u8>, pos: usize, needed: usize) -> WriteResult<()> {
+    fn maybe_grow(inner: &mut Vec<u8>, pos: usize, needed: usize) -> WriteResult<()> {
         let Some(required) = pos.checked_add(needed) else {
             return Err(write_size_limit(needed));
         };
@@ -299,8 +299,7 @@ mod vec {
     ///
     /// If `pos > inner.len()`, the range `inner.len()..pos` must be spare capacity
     /// owned by `inner` and valid to write as `MaybeUninit<u8>`. This function
-    /// initializes that entire gap with zero bytes and then sets `inner.len()` to
-    /// `pos`.
+    /// initializes that entire gap with zero bytes.
     ///
     /// Callers should normally establish this by calling `maybe_grow(inner, pos, n)`
     /// with any `n` such that `pos + n` is checked and fits in the vector capacity.
@@ -314,9 +313,24 @@ mod vec {
                 spare
                     .get_unchecked_mut(..init_gap)
                     .fill(MaybeUninit::new(0));
-                inner.set_len(pos);
             }
         }
+    }
+
+    /// Prepare `inner` for a write of `needed` bytes starting at cursor position `pos`.
+    ///
+    /// This checks that `pos + needed` fits in `usize`, ensures the vector has enough
+    /// capacity for the whole write window, and zero-initializes any sparse gap between
+    /// the current length and `pos`. It does not change the vector's length: callers must
+    /// only expose newly initialized bytes after the write window itself has been
+    /// initialized, typically via [`add_len`] or an equivalent `set_len`.
+    #[inline]
+    pub(crate) fn prepare_write(inner: &mut Vec<u8>, pos: usize, needed: usize) -> WriteResult<()> {
+        maybe_grow(inner, pos, needed)?;
+        // SAFETY: `maybe_grow` checked `pos + needed` and ensured capacity for it,
+        // so `inner.capacity() >= pos`; `zero_fill_gap` only writes `inner.len()..pos`.
+        unsafe { zero_fill_gap(inner, pos) };
+        Ok(())
     }
 
     /// Add `len` to the cursor's position and update the length of the vector if necessary.
@@ -340,15 +354,11 @@ mod vec {
 
     /// Write `src` to the vector at the current position and advance the position by `src.len()`.
     pub(super) fn write(inner: &mut Vec<u8>, pos: &mut usize, src: &[u8]) -> WriteResult<()> {
-        maybe_grow(inner, *pos, src.len())?;
-        // SAFETY: `maybe_grow` checked `*pos + src.len()` and ensured capacity
-        // for it, so `inner.capacity() >= *pos`; `zero_fill_gap` only writes
-        // `inner.len()..*pos`.
-        unsafe { zero_fill_gap(inner, *pos) };
-        // SAFETY: `maybe_grow` ensured at least `*pos + src.len()` capacity is
+        prepare_write(inner, *pos, src.len())?;
+        // SAFETY: `prepare_write` ensured at least `*pos + src.len()` capacity is
         // available.
         unsafe { ptr::copy_nonoverlapping(src.as_ptr(), inner.as_mut_ptr().add(*pos), src.len()) };
-        // SAFETY: `zero_fill_gap` initialized any gap before `*pos`, and we
+        // SAFETY: `prepare_write` initialized any gap before `*pos`, and we
         // just wrote `src.len()` bytes starting at `*pos`.
         unsafe { add_len(inner, pos, src.len()) };
         Ok(())
@@ -360,11 +370,7 @@ mod vec {
         pos: &'a mut usize,
         n_bytes: usize,
     ) -> WriteResult<impl Writer> {
-        maybe_grow(inner, *pos, n_bytes)?;
-        // SAFETY: `maybe_grow` checked `*pos + n_bytes` and ensured capacity
-        // for it, so `inner.capacity() >= *pos`; `zero_fill_gap` only writes
-        // `inner.len()..*pos`.
-        unsafe { zero_fill_gap(inner, *pos) };
+        prepare_write(inner, *pos, n_bytes)?;
         // SAFETY: by calling `as_trusted_for`, caller guarantees they
         // will fully initialize `n_bytes` of memory and will not write
         // beyond the bounds of the slice.

--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -323,6 +323,7 @@ mod vec {
     ///
     /// # SAFETY:
     /// - Must be called after a successful write to the vector.
+    #[inline(always)]
     pub(super) unsafe fn add_len(inner: &mut Vec<u8>, pos: &mut usize, len: usize) {
         // SAFETY: We just wrote `len` bytes to the vector, so `pos + len` is valid.
         let next_pos = unsafe { pos.unchecked_add(len) };
@@ -394,11 +395,6 @@ impl<'a> CursorVecUnchecked<'a> {
 impl<'a> Writer for CursorVecUnchecked<'a> {
     #[inline]
     fn write(&mut self, src: &[u8]) -> WriteResult<()> {
-        let cur_len = self.inner.len();
-        let cur_pos = *self.pos;
-        #[expect(clippy::arithmetic_side_effects)]
-        let next_pos = cur_pos + src.len();
-
         // SAFETY:
         // - `as_trusted_for` ensured sufficient capacity for the trusted window before
         //   constructing this writer.
@@ -409,19 +405,15 @@ impl<'a> Writer for CursorVecUnchecked<'a> {
         unsafe {
             copy_nonoverlapping(
                 src.as_ptr(),
-                self.inner.as_mut_ptr().add(cur_pos),
+                self.inner.as_mut_ptr().add(*self.pos),
                 src.len(),
             );
         }
 
-        if next_pos > cur_len {
-            // SAFETY: any gap before the trusted window was initialized before
-            // constructing this writer, and this call just initialized the bytes
-            // from the previous cursor position through `next_pos`.
-            unsafe { self.inner.set_len(next_pos) }
-        }
-
-        *self.pos = next_pos;
+        // SAFETY: any gap before the trusted window was initialized before
+        // constructing this writer, and this call just initialized the bytes
+        // from the previous cursor position through `next_pos`.
+        unsafe { vec::add_len(self.inner, self.pos, src.len()) }
 
         Ok(())
     }

--- a/wincode/src/io/std_write.rs
+++ b/wincode/src/io/std_write.rs
@@ -1,6 +1,5 @@
 use {
     crate::io::{WriteResult, Writer, slice::SliceMutUnchecked, write_size_limit},
-    core::mem::MaybeUninit,
     std::io::{BufWriter, Cursor, Write},
 };
 
@@ -134,36 +133,9 @@ fn cursor_vec_as_trusted_for(
     let Ok(pos) = usize::try_from(cursor.position()) else {
         return Err(write_size_limit(usize::MAX));
     };
-    let Some(next_pos) = pos.checked_add(n_bytes) else {
-        return Err(write_size_limit(n_bytes));
-    };
 
     let vec = cursor.get_mut().as_mut();
-    let cur_len = vec.len();
-    // Ensure total capacity is at least `next_pos`, so the reserved
-    // trusted window `[pos..next_pos)` is backed by the vector.
-    if next_pos > vec.capacity() {
-        #[expect(clippy::arithmetic_side_effects)]
-        // `next_pos > capacity && cur_len <= capacity` by invariant
-        vec.reserve(next_pos - cur_len);
-    }
-
-    // Zero-fill the gap between `cur_len` and `pos` (if any).
-    //
-    // Behaviorally consistent with `std::io::Write::write_all` for
-    // `Cursor<Vec<u8>>`.
-    if let Some(init_gap) = pos.checked_sub(cur_len) {
-        let spare = vec.spare_capacity_mut();
-        debug_assert!(spare.len() >= init_gap);
-        // SAFETY: after the optional reserve above, `capacity >= next_pos`.
-        // When `init_gap` exists, `init_gap = pos - cur_len` and `pos <= next_pos`,
-        // so `init_gap <= capacity - cur_len == spare.len()`.
-        unsafe {
-            spare
-                .get_unchecked_mut(..init_gap)
-                .fill(MaybeUninit::new(0))
-        }
-    }
+    crate::io::cursor::vec::prepare_write(vec, pos, n_bytes)?;
 
     // SAFETY: by calling `as_trusted_for`, caller guarantees they
     // will fully initialize `n_bytes` of memory and will not write

--- a/wincode/src/io/std_write.rs
+++ b/wincode/src/io/std_write.rs
@@ -165,33 +165,77 @@ fn cursor_vec_as_trusted_for(
         }
     }
 
-    if next_pos > cur_len {
-        // SAFETY:
-        // - The contract of `as_trusted_for` requires that the caller initialize the
-        //   entire reserved window `[pos..next_pos)` before using the parent writer again.
-        // - The buffer contains only bytes (Vec<u8>), so there is no drop implementation
-        //   that must be considered.
-        unsafe { vec.set_len(next_pos) }
-    }
-    cursor.set_position(next_pos as u64);
-
-    // SAFETY: `vec.reserve` above ensures that at least `pos + n_bytes`
-    // (`next_pos`) capacity is available.
-    let slice = unsafe {
-        core::slice::from_raw_parts_mut(
-            cursor
-                .get_mut()
-                .as_mut()
-                .as_mut_ptr()
-                .cast::<MaybeUninit<u8>>()
-                .add(pos),
-            n_bytes,
-        )
-    };
     // SAFETY: by calling `as_trusted_for`, caller guarantees they
     // will fully initialize `n_bytes` of memory and will not write
     // beyond the bounds of the slice.
-    Ok(unsafe { SliceMutUnchecked::new(slice) })
+    Ok(unsafe { CursorVecUnchecked::new(cursor) })
+}
+
+struct CursorVecUnchecked<'a, T> {
+    inner: &'a mut Cursor<T>,
+}
+
+impl<'a, T> CursorVecUnchecked<'a, T> {
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner.position()` fits within the backing
+    /// vector's capacity, that any gap before that position has already been
+    /// initialized, and that all writes through this writer stay within the
+    /// trusted window reserved by `as_trusted_for`.
+    const unsafe fn new(inner: &'a mut Cursor<T>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, T> Writer for CursorVecUnchecked<'a, T>
+where
+    T: AsMut<Vec<u8>>,
+{
+    #[inline]
+    fn write(&mut self, src: &[u8]) -> WriteResult<()> {
+        let cur_pos = self.inner.position();
+        let inner = self.inner.get_mut().as_mut();
+        let cur_len = inner.len();
+        // `cursor_vec_as_trusted_for` checked that the trusted window end fits in
+        // `usize`, and the trusted contract requires `next_pos` to stay within that
+        // window.
+        #[expect(clippy::arithmetic_side_effects)]
+        let next_pos = cur_pos + src.len() as u64;
+
+        // SAFETY:
+        // - `cursor_vec_as_trusted_for` ensured sufficient capacity for the trusted window before
+        //   constructing this writer.
+        // - The trusted-writer contract requires all writes through this writer to stay
+        //   within that reserved window.
+        // - Given Rust's aliasing rules, we can assume that `src` does not overlap with
+        //   the internal buffer.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                src.as_ptr(),
+                // `cursor_vec_as_trusted_for` checked that the initial cursor
+                // position plus the trusted window fits in `usize`. The trusted-writer
+                // contract requires all writes through this writer to stay within that
+                // reserved window, so `cur_pos` also fits in `usize`.
+                inner.as_mut_ptr().add(cur_pos as usize),
+                src.len(),
+            );
+        }
+
+        if next_pos > cur_len as u64 {
+            // SAFETY: any gap before the trusted window was initialized before
+            // constructing this writer, and the copy above initialized `cur_pos..next_pos`.
+            unsafe {
+                // `cursor_vec_as_trusted_for` checked that the trusted window end fits in
+                // `usize`, and the trusted contract requires `next_pos` to stay within that
+                // window.
+                inner.set_len(next_pos as usize)
+            }
+        }
+
+        self.inner.set_position(next_pos);
+
+        Ok(())
+    }
 }
 
 impl Writer for Cursor<Vec<u8>> {
@@ -348,6 +392,20 @@ mod tests {
             cursor.finish().unwrap();
 
             assert_eq!(&cursor.into_inner()[..], &vec![1, 2, 3, 0, 0, 0, 9, 10]);
+        });
+    }
+
+    #[test]
+    fn cursor_vec_trusted_does_not_extend_len_before_write() {
+        let mut inner = Vec::with_capacity(16);
+        with_vec_cursors!(inner, |cursor| {
+            {
+                let _trusted = unsafe { cursor.as_trusted_for(8) }.unwrap();
+            }
+
+            cursor.finish().unwrap();
+
+            assert_eq!(cursor.into_inner().len(), 0);
         });
     }
 

--- a/wincode/src/io/vec.rs
+++ b/wincode/src/io/vec.rs
@@ -1,4 +1,48 @@
-use {super::*, alloc::vec::Vec, slice::SliceMutUnchecked};
+use {super::*, alloc::vec::Vec};
+
+struct VecUnchecked<'a> {
+    inner: &'a mut Vec<u8>,
+}
+
+impl<'a> VecUnchecked<'a> {
+    /// # Safety
+    ///
+    /// Caller must ensure that `inner` has enough spare capacity for all writes
+    /// performed through this unchecked writer, and that those writes stay within
+    /// the trusted window reserved by `as_trusted_for`.
+    const unsafe fn new(inner: &'a mut Vec<u8>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a> Writer for VecUnchecked<'a> {
+    #[inline]
+    fn write(&mut self, src: &[u8]) -> WriteResult<()> {
+        let cur_len = self.inner.len();
+
+        // SAFETY:
+        // - The outer `as_trusted_for` call ensured sufficient capacity for the trusted
+        //   window before constructing this writer.
+        // - The trusted-writer contract requires all writes through this writer,
+        //   including forwarded nested trusted writes, to stay within that window.
+        // - Given Rust's aliasing rules, we can assume that `src` does not overlap with
+        //   the internal buffer.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                src.as_ptr(),
+                self.inner.as_mut_ptr().add(cur_len),
+                src.len(),
+            );
+        }
+
+        unsafe {
+            #[expect(clippy::arithmetic_side_effects)]
+            self.inner.set_len(cur_len + src.len())
+        }
+
+        Ok(())
+    }
+}
 
 /// Writer implementation for `Vec<u8>` that appends to the vector. The vector will grow as needed.
 ///
@@ -35,31 +79,11 @@ impl Writer for Vec<u8> {
 
     #[inline]
     unsafe fn as_trusted_for(&mut self, n_bytes: usize) -> WriteResult<impl Writer> {
-        let cur_len = self.len();
         self.reserve(n_bytes);
-        // SAFETY:
-        // - The contract of `as_trusted_for` requires that the caller initialize exactly
-        //   `n_bytes` of memory.
-        // - The buffer contains only bytes (Vec<u8>), so there is no drop implementation
-        //   that must be considered.
-        #[allow(clippy::uninit_vec)]
-        unsafe {
-            self.set_len(cur_len.unchecked_add(n_bytes))
-        };
-
-        // SAFETY: `self.reserve` above ensures that at least `cur_len + n_bytes`
-        // capacity is available.
-        let slice = unsafe {
-            from_raw_parts_mut(
-                self.as_mut_ptr().cast::<MaybeUninit<u8>>().add(cur_len),
-                n_bytes,
-            )
-        };
-
         // SAFETY: by calling `as_trusted_for`, caller guarantees they
         // will fully initialize `n_bytes` of memory and will not write
-        // beyond the bounds of the slice.
-        Ok(unsafe { SliceMutUnchecked::new(slice) })
+        // beyond the bounds of returned `Writer`.
+        Ok(unsafe { VecUnchecked::new(self) })
     }
 }
 
@@ -141,5 +165,26 @@ mod tests {
             unsafe { writer.write_slice_t(&ints).unwrap() };
             prop_assert_eq!(writer, bytes);
         }
+    }
+
+    #[test]
+    fn vec_trusted_writer_does_not_extend_len_before_write() {
+        let mut vec = Vec::with_capacity(8);
+        {
+            let _trusted = unsafe { vec.as_trusted_for(8) }.unwrap();
+        }
+
+        assert_eq!(vec.len(), 0);
+    }
+
+    #[test]
+    fn vec_trusted_writer_extends_len_only_for_written_bytes() {
+        let mut vec = Vec::with_capacity(8);
+        {
+            let mut trusted = unsafe { vec.as_trusted_for(8) }.unwrap();
+            trusted.write(&[1, 2, 3]).unwrap();
+        }
+
+        assert_eq!(vec, [1, 2, 3]);
     }
 }

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -3757,6 +3757,20 @@ mod tests {
     }
 
     #[test]
+    fn test_static_tuple_write_error_leaves_only_initialized_prefix() {
+        let before_epoch = UNIX_EPOCH.checked_sub(Duration::from_secs(1)).unwrap();
+        let value = (0xAAu8, before_epoch);
+        let mut bytes = Vec::new();
+
+        assert!(crate::serialize_into(&mut bytes, &value).is_err());
+        #[cfg(miri)]
+        if bytes.len() > 1 {
+            let _ = core::hint::black_box(bytes[1]);
+        }
+        assert_eq!(bytes, [0xAA]);
+    }
+
+    #[test]
     fn test_deserialize_exact_accepts_exact_input() {
         let bytes = serialize(&123u64).unwrap();
         let value: u64 = deserialize_exact(&bytes).unwrap();


### PR DESCRIPTION
Closes #306 