### PR TITLE
Fix derive name collisions

### DIFF
--- a/wincode-derive/src/assert_zero_copy.rs
+++ b/wincode-derive/src/assert_zero_copy.rs
@@ -52,28 +52,27 @@ pub(crate) fn assert_zero_copy(args: &SchemaArgs, repr: &StructRepr) -> Result<T
 
     Ok(quote! {
         const _: () = {
-            use #crate_name::{config::ZeroCopy, SchemaRead, TypeMeta};
             // Assert the struct implements `SchemaRead`.
             const _assert_schema_read_impl: fn() = || {
-                fn assert_schema_read_impl<'de, T: SchemaRead<'de, #config_path>>() {}
+                fn assert_schema_read_impl<'de, T: #crate_name::SchemaRead<'de, #config_path>>() {}
                 assert_schema_read_impl::<#ident>()
             };
 
             // Assert the struct itself implements `ZeroCopy`.
             const _assert_struct_zerocopy_impl: fn() = || {
-                fn assert_struct_zerocopy_impl<T: ZeroCopy<#config_path>>() {}
+                fn assert_struct_zerocopy_impl<T: #crate_name::config::ZeroCopy<#config_path>>() {}
                 assert_struct_zerocopy_impl::<#ident>()
             };
 
             // Assert all fields implement `ZeroCopy`.
             const _assert_field_zerocopy_impl: fn() = || {
-                fn assert_field_zerocopy_impl<T: ZeroCopy<#config_path>>() {}
+                fn assert_field_zerocopy_impl<T: #crate_name::config::ZeroCopy<#config_path>>() {}
                 #(#zero_copy_field_asserts);*
             };
 
             // Assert the struct has no padding bytes.
             const _assert_no_padding: () = {
-                if let TypeMeta::Static { size, .. } = <#ident as SchemaRead<'_, #config_path>>::TYPE_META {
+                if let #crate_name::TypeMeta::Static { size, .. } = <#ident as #crate_name::SchemaRead<'_, #config_path>>::TYPE_META {
                     if size != core::mem::size_of::<#ident>() {
                         panic!("wincode(assert_zero_copy) was applied to a type with padding");
                     }

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -199,7 +199,12 @@ impl Field {
 }
 
 pub(crate) trait FieldsExt {
-    fn type_meta_impl(&self, trait_impl: TraitImpl, repr: &StructRepr) -> TokenStream;
+    fn type_meta_impl(
+        &self,
+        trait_impl: TraitImpl,
+        repr: &StructRepr,
+        crate_name: &Path,
+    ) -> TokenStream;
     /// Get an iterator over the fields and their identifiers for the struct members.
     ///
     /// If the field has a named identifier, return it.
@@ -223,19 +228,24 @@ pub(crate) trait FieldsExt {
 
 impl FieldsExt for Fields<Field> {
     /// Generate the `TYPE_META` implementation for a struct.
-    fn type_meta_impl(&self, trait_impl: TraitImpl, repr: &StructRepr) -> TokenStream {
+    fn type_meta_impl(
+        &self,
+        trait_impl: TraitImpl,
+        repr: &StructRepr,
+        crate_name: &Path,
+    ) -> TokenStream {
         let tuple_expansion = match trait_impl {
             TraitImpl::SchemaRead => {
                 let items = self.unskipped_iter().map(|field| {
                     let target = field.target_resolved().with_lifetime("de");
-                    quote! { <#target as SchemaRead<'de, WincodeConfig>>::TYPE_META }
+                    quote! { <#target as #crate_name::SchemaRead<'de, __WincodeConfig>>::TYPE_META }
                 });
                 quote! { #(#items),* }
             }
             TraitImpl::SchemaWrite => {
                 let items = self.unskipped_iter().map(|field| {
                     let target = field.target_resolved();
-                    quote! { <#target as SchemaWrite<WincodeConfig>>::TYPE_META }
+                    quote! { <#target as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META }
                 });
                 quote! { #(#items),* }
             }
@@ -249,15 +259,15 @@ impl FieldsExt for Fields<Field> {
         //   and the zero-copy eligibility the struct representation (e.g., `#[repr(transparent)]` or `#[repr(C)]`).
         quote! {
             // If any field is not `TypeMeta::Static`, the sum type will not match and `Dynamic` case will be used
-            if let TypeMeta::Static { size: serialized_size, zero_copy } = TypeMeta::join_types([#tuple_expansion]) {
+            if let #crate_name::TypeMeta::Static { size: serialized_size, zero_copy } = #crate_name::TypeMeta::join_types([#tuple_expansion]) {
                 // Bincode never serializes padding, so for types to qualify for zero-copy, the summed serialized size of
                 // the fields must be equal to the in-memory size of the type. This is because zero-copy types
                 // may be read/written directly using their in-memory representation; padding disqualifies a type
                 // from this kind of optimization.
                 let no_padding = serialized_size == core::mem::size_of::<Self>();
-                TypeMeta::Static { size: serialized_size, zero_copy: no_padding && #is_zero_copy_eligible && zero_copy }
+                #crate_name::TypeMeta::Static { size: serialized_size, zero_copy: no_padding && #is_zero_copy_eligible && zero_copy }
             } else {
-                TypeMeta::Dynamic
+                #crate_name::TypeMeta::Dynamic
             }
         }
     }
@@ -337,13 +347,23 @@ impl Variant {
 
 pub(crate) trait VariantsExt {
     /// Generate the `TYPE_META` implementation for an enum.
-    fn type_meta_impl(&self, trait_impl: TraitImpl, tag_encoding: &Type) -> TokenStream;
+    fn type_meta_impl(
+        &self,
+        trait_impl: TraitImpl,
+        tag_encoding: &Type,
+        crate_name: &Path,
+    ) -> TokenStream;
 }
 
 impl VariantsExt for &[Variant] {
-    fn type_meta_impl(&self, trait_impl: TraitImpl, tag_encoding: &Type) -> TokenStream {
+    fn type_meta_impl(
+        &self,
+        trait_impl: TraitImpl,
+        tag_encoding: &Type,
+        crate_name: &Path,
+    ) -> TokenStream {
         if self.is_empty() {
-            return quote! { TypeMeta::Static { size: 0, zero_copy: false } };
+            return quote! { #crate_name::TypeMeta::Static { size: 0, zero_copy: false } };
         }
 
         // Enums have a statically known size in a very specific case: all variants have the same serialized size.
@@ -357,10 +377,10 @@ impl VariantsExt for &[Variant] {
             .collect::<Vec<_>>();
         let tag_expr = match trait_impl {
             TraitImpl::SchemaRead => {
-                quote! { <#tag_encoding as SchemaRead<'de, WincodeConfig>>::TYPE_META }
+                quote! { <#tag_encoding as #crate_name::SchemaRead<'de, __WincodeConfig>>::TYPE_META }
             }
             TraitImpl::SchemaWrite => {
-                quote! { <#tag_encoding as SchemaWrite<WincodeConfig>>::TYPE_META }
+                quote! { <#tag_encoding as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META }
             }
         };
         let variant_type_metas = self
@@ -373,14 +393,14 @@ impl VariantsExt for &[Variant] {
                         TraitImpl::SchemaRead => {
                             let items = variant.fields.unskipped_iter().map(|field| {
                                 let target = field.target_resolved().with_lifetime("de");
-                                quote! { <#target as SchemaRead<'de, WincodeConfig>>::TYPE_META }
+                                quote! { <#target as #crate_name::SchemaRead<'de, __WincodeConfig>>::TYPE_META }
                             });
                             quote! { #(#items),* }
                         },
                         TraitImpl::SchemaWrite => {
                             let items = variant.fields.unskipped_iter().map(|field| {
                                 let target = field.target_resolved();
-                                quote! { <#target as SchemaWrite<WincodeConfig>>::TYPE_META }
+                                quote! { <#target as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META }
                             });
                             quote! { #(#items),* }
                         },
@@ -388,7 +408,7 @@ impl VariantsExt for &[Variant] {
                     // Assign the `TYPE_META` to a local variant identifier (`#ident`).
                     quote! {
                         // Sum the discriminant size and the sizes of the fields. Enums are never zero-copy
-                        let #ident = TypeMeta::join_types([#tag_expr, #fields_type_meta_expansion]).keep_zero_copy(false);
+                        let #ident = #crate_name::TypeMeta::join_types([#tag_expr, #fields_type_meta_expansion]).keep_zero_copy(false);
                     }
                 }
                 Style::Unit => {
@@ -398,10 +418,10 @@ impl VariantsExt for &[Variant] {
                     // invalid bit patterns.
                     quote! {
                         let #ident = match #tag_expr {
-                            TypeMeta::Static { size, .. } => {
-                                TypeMeta::Static { size, zero_copy: false }
+                            #crate_name::TypeMeta::Static { size, .. } => {
+                                #crate_name::TypeMeta::Static { size, zero_copy: false }
                             }
-                            TypeMeta::Dynamic => TypeMeta::Dynamic,
+                            #crate_name::TypeMeta::Dynamic => #crate_name::TypeMeta::Dynamic,
                         };
                     }
                 }
@@ -418,7 +438,7 @@ impl VariantsExt for &[Variant] {
                 /// and have the same size.
                 ///
                 /// This logic is broken into a function so that we can use `return`.
-                const fn choose(variant_sizes: &[TypeMeta]) -> TypeMeta {
+                const fn choose(variant_sizes: &[#crate_name::TypeMeta]) -> #crate_name::TypeMeta {
                     // If there is only one variant, it's safe to use that variant's `TypeMeta`.
                     //
                     // Note we check if there are 0 variants at the top of this function and exit early.
@@ -430,13 +450,13 @@ impl VariantsExt for &[Variant] {
                     while i < variant_sizes.len() {
                         match (variant_sizes[i], variant_sizes[0]) {
                             // Iff every variant is `TypeMeta::Static` and has the same size, we can assume the type is static.
-                            (TypeMeta::Static { size: s1, .. }, TypeMeta::Static { size: s2, .. }) if s1 == s2 => {
+                            (#crate_name::TypeMeta::Static { size: s1, .. }, #crate_name::TypeMeta::Static { size: s2, .. }) if s1 == s2 => {
                                 // Check the next variant.
                                 i += 1;
                             }
                             _ => {
                                 // If any variant is not `TypeMeta::Static` or has a different size, the enum is dynamic.
-                                return TypeMeta::Dynamic;
+                                return #crate_name::TypeMeta::Dynamic;
                             }
                         }
                     }
@@ -615,7 +635,7 @@ impl FromMeta for AssertZeroCopyConfig {
 /// for friendlier naming.
 #[inline]
 pub(crate) fn default_tag_encoding() -> Type {
-    parse_quote!(WincodeConfig::TagEncoding)
+    parse_quote!(__WincodeConfig::TagEncoding)
 }
 
 /// Metadata about the `#[repr]` attribute on a struct.

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -15,7 +15,7 @@ use {
     proc_macro2::TokenStream,
     quote::{quote, quote_spanned},
     syn::{
-        DeriveInput, GenericParam, Generics, PredicateType, Token, Type, WhereClause,
+        DeriveInput, GenericParam, Generics, Path, PredicateType, Token, Type, WhereClause,
         WherePredicate, parse_quote, punctuated::Punctuated,
     },
 };
@@ -24,11 +24,12 @@ fn impl_struct(
     args: &SchemaArgs,
     fields: &Fields<Field>,
     repr: &StructRepr,
+    crate_name: &Path,
 ) -> (TokenStream, TokenStream) {
     if fields.is_empty() {
         return (
             quote! {},
-            quote! { TypeMeta::Static {
+            quote! { #crate_name::TypeMeta::Static {
                 size: 0,
                 zero_copy: true,
             }},
@@ -53,9 +54,9 @@ fn impl_struct(
                 // }
                 // ```
                 let ty = field.ty.with_lifetime("de");
-                quote! { MaybeUninit<#ty> }
+                quote! { ::core::mem::MaybeUninit<#ty> }
             } else {
-                quote! { MaybeUninit<_> }
+                quote! { ::core::mem::MaybeUninit<_> }
             };
             let init_count = if i == num_fields - 1 {
                 quote! {}
@@ -70,8 +71,8 @@ fn impl_struct(
                 }
             } else {
                 quote! {
-                    <#target as SchemaRead<'de, WincodeConfig>>::read(
-                        reader.by_ref(),
+                    <#target as #crate_name::SchemaRead<'de, __WincodeConfig>>::read(
+                        #crate_name::io::Reader::by_ref(&mut reader),
                         unsafe { &mut *(&raw mut (*dst_ptr).#ident).cast::<#hint>() }
                     )?;
                     #init_count
@@ -80,7 +81,7 @@ fn impl_struct(
         })
         .collect::<Vec<_>>();
 
-    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaRead, repr);
+    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaRead, repr, crate_name);
 
     let drop_guard = (0..fields.len()).map(|i| {
         // Generate code to drop already initialized fields in reverse order.
@@ -91,7 +92,7 @@ fn impl_struct(
             .map(|(j, field)| {
                 let ident = field.struct_member_ident(i - 1 - j);
                 quote! {
-                    ptr::drop_in_place(&raw mut (*dst_ptr).#ident);
+                    ::core::ptr::drop_in_place(&raw mut (*dst_ptr).#ident);
                 }
             });
         let cnt = i as u8;
@@ -112,7 +113,7 @@ fn impl_struct(
     let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
     let init_guard = quote! {
         let dst_ptr = dst.as_mut_ptr();
-        let mut guard = DropGuard {
+        let mut guard = __WincodeDropGuard {
             init_count: 0,
             dst_ptr,
         };
@@ -120,12 +121,12 @@ fn impl_struct(
     };
     (
         quote! {
-            struct DropGuard #impl_generics #where_clause {
+            struct __WincodeDropGuard #impl_generics #where_clause {
                 init_count: u8,
                 dst_ptr: *mut #dst,
             }
 
-            impl #impl_generics ::core::ops::Drop for DropGuard #ty_generics #where_clause {
+            impl #impl_generics ::core::ops::Drop for __WincodeDropGuard #ty_generics #where_clause {
                 #[cold]
                 fn drop(&mut self) {
                     let dst_ptr = self.dst_ptr;
@@ -138,21 +139,21 @@ fn impl_struct(
                 }
             }
 
-            match <Self as SchemaRead<'de, WincodeConfig>>::TYPE_META {
-                TypeMeta::Static { size, .. } => {
+            match <Self as #crate_name::SchemaRead<'de, __WincodeConfig>>::TYPE_META {
+                #crate_name::TypeMeta::Static { size, .. } => {
                     // SAFETY: `size` is the serialized size of the struct, which is the sum
                     // of the serialized sizes of the fields.
                     // Calling `read` on each field will consume exactly `size` bytes,
                     // fully consuming the trusted window.
-                    let mut reader = unsafe { reader.as_trusted_for(size) }?;
+                    let mut reader = unsafe { #crate_name::io::Reader::as_trusted_for(&mut reader, size) }?;
                     #init_guard
                     #(#read_impl)*
-                    mem::forget(guard);
+                    ::core::mem::forget(guard);
                 }
-                TypeMeta::Dynamic => {
+                #crate_name::TypeMeta::Dynamic => {
                     #init_guard
                     #(#read_impl)*
-                    mem::forget(guard);
+                    ::core::mem::forget(guard);
                 }
             }
         },
@@ -166,17 +167,19 @@ fn impl_enum(
     enum_ident: &Type,
     variants: &[Variant],
     tag_encoding_override: Option<&Type>,
+    crate_name: &Path,
 ) -> (TokenStream, TokenStream) {
     if variants.is_empty() {
         return (
-            quote! { return Err(error::invalid_value("cannot deserialize uninhabited enum")); },
-            quote! { TypeMeta::Dynamic },
+            quote! { return Err(#crate_name::error::invalid_value("cannot deserialize uninhabited enum")); },
+            quote! { #crate_name::TypeMeta::Dynamic },
         );
     }
 
     let type_meta_impl = variants.type_meta_impl(
         TraitImpl::SchemaRead,
         tag_encoding_override.unwrap_or(&default_tag_encoding()),
+        crate_name,
     );
 
     let read_impl = variants.iter().enumerate().map(|(i, variant)| {
@@ -204,7 +207,7 @@ fn impl_enum(
                             quote! { let #ident = #val; }
                         } else {
                             quote! {
-                                let #ident = <#target as SchemaRead<'de, WincodeConfig>>::get(reader.by_ref())?;
+                                let #ident = <#target as #crate_name::SchemaRead<'de, __WincodeConfig>>::get(#crate_name::io::Reader::by_ref(&mut reader))?;
                             }
                         };
                         construct_idents.push(ident);
@@ -215,7 +218,7 @@ fn impl_enum(
                 // No prefix disambiguation needed, as we are matching on a discriminant integer.
                 let static_targets = fields.unskipped_iter().map(|field| {
                     let target = field.target_resolved().with_lifetime("de");
-                    quote! {<#target as SchemaRead<'de, WincodeConfig>>::TYPE_META}
+                    quote! {<#target as #crate_name::SchemaRead<'de, __WincodeConfig>>::TYPE_META}
                 });
 
                 let constructor = if style.is_struct() {
@@ -230,12 +233,12 @@ fn impl_enum(
 
                 quote! {
                     #discriminant => {
-                        if let TypeMeta::Static { size: summed_sizes, .. } = TypeMeta::join_types([#(#static_targets),*]) {
+                        if let #crate_name::TypeMeta::Static { size: summed_sizes, .. } = #crate_name::TypeMeta::join_types([#(#static_targets),*]) {
                             // SAFETY: `summed_sizes` is the sum of the static sizes of the fields,
                             // which is the serialized size of the variant.
                             // Calling `read` on each field will consume exactly `summed_sizes` bytes,
                             // fully consuming the trusted window.
-                            let mut reader = unsafe { reader.as_trusted_for(summed_sizes) }?;
+                            let mut reader = unsafe { #crate_name::io::Reader::as_trusted_for(&mut reader, summed_sizes) }?;
                             #(#read)*
                             dst.write(#constructor);
                         } else {
@@ -256,11 +259,13 @@ fn impl_enum(
 
     let read_discriminant = if let Some(tag_encoding) = tag_encoding_override {
         quote! {
-            <#tag_encoding as SchemaRead<'de, WincodeConfig>>::get(reader.by_ref())?;
+            <#tag_encoding as #crate_name::SchemaRead<'de, __WincodeConfig>>::get(#crate_name::io::Reader::by_ref(&mut reader))?;
         }
     } else {
         quote! {
-            WincodeConfig::TagEncoding::try_into_u32(WincodeConfig::TagEncoding::get(reader.by_ref())?)?
+            <__WincodeConfig::TagEncoding as #crate_name::tag_encoding::TagEncoding<__WincodeConfig>>::try_into_u32(
+                <__WincodeConfig::TagEncoding as #crate_name::SchemaRead<'de, __WincodeConfig>>::get(#crate_name::io::Reader::by_ref(&mut reader))?,
+            )?
         }
     };
 
@@ -269,7 +274,7 @@ fn impl_enum(
             let discriminant = #read_discriminant;
             match discriminant {
                 #(#read_impl)*
-                _ => return Err(error::invalid_tag_encoding(discriminant as usize)),
+                _ => return Err(#crate_name::error::invalid_tag_encoding(discriminant as usize)),
             }
         },
         quote! {
@@ -307,18 +312,18 @@ fn append_de_lifetime(generics: &mut Generics) {
         .push(GenericParam::Lifetime(parse_quote!('de: #(#lifetimes)+*)));
 }
 
-fn append_config(generics: &mut Generics) {
-    generics
-        .params
-        .push(GenericParam::Type(parse_quote!(WincodeConfig: Config)));
+fn append_config(generics: &mut Generics, crate_name: &Path) {
+    generics.params.push(GenericParam::Type(
+        parse_quote!(__WincodeConfig: #crate_name::config::Config),
+    ));
 }
 
-fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>) {
+fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>, crate_name: &Path) {
     let mut predicates: Punctuated<WherePredicate, Token![,]> = Punctuated::new();
     for param in generics.type_params() {
         let ident = &param.ident;
         let mut bounds = Punctuated::new();
-        bounds.push(parse_quote!(SchemaRead<'de, WincodeConfig, Dst = #ident>));
+        bounds.push(parse_quote!(#crate_name::SchemaRead<'de, __WincodeConfig, Dst = #ident>));
 
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
@@ -329,7 +334,7 @@ fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>) {
     }
 
     /// Append an additional constraint to the where clause such that
-    /// `SchemaRead<'de, WincodeConfig>` is implemented for the given
+    /// `SchemaRead<'de, __WincodeConfig>` is implemented for the given
     /// field's type.
     ///
     /// This constraint is only necessary for fields whose types contain lifetimes.
@@ -341,11 +346,12 @@ fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>) {
     fn constrain_reference_type(
         field: &Field,
         predicates: &mut Punctuated<WherePredicate, Token![,]>,
+        crate_name: &Path,
     ) {
         let ty = &field.ty.with_lifetime("de");
         let target = field.target_resolved().with_lifetime("de");
         let mut bounds = Punctuated::new();
-        bounds.push(parse_quote!(SchemaRead<'de, WincodeConfig, Dst = #ty>));
+        bounds.push(parse_quote!(#crate_name::SchemaRead<'de, __WincodeConfig, Dst = #ty>));
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
             bounded_ty: target,
@@ -357,13 +363,13 @@ fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>) {
     match data {
         Data::Struct(fields) => {
             for field in fields.fields_with_lifetime_iter() {
-                constrain_reference_type(field, &mut predicates);
+                constrain_reference_type(field, &mut predicates, crate_name);
             }
         }
         Data::Enum(variants) => {
             for variant in variants {
                 for field in variant.fields.fields_with_lifetime_iter() {
-                    constrain_reference_type(field, &mut predicates);
+                    constrain_reference_type(field, &mut predicates, crate_name);
                 }
             }
         }
@@ -376,22 +382,26 @@ fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>) {
     where_clause.predicates.extend(predicates);
 }
 
-fn append_generics(generics: &Generics, data: &Data<Variant, Field>) -> Generics {
+fn append_generics(
+    generics: &Generics,
+    data: &Data<Variant, Field>,
+    crate_name: &Path,
+) -> Generics {
     let mut generics = generics.clone();
     append_de_lifetime(&mut generics);
-    append_where_clause(&mut generics, data);
-    append_config(&mut generics);
+    append_where_clause(&mut generics, data, crate_name);
+    append_config(&mut generics, crate_name);
     generics
 }
 
 pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let repr = extract_repr(&input, "SchemaRead")?;
     let args = SchemaArgs::from_derive_input(&input)?;
-    let appended_generics = append_generics(&args.generics, &args.data);
+    let crate_name = get_crate_name(&args);
+    let appended_generics = append_generics(&args.generics, &args.data, &crate_name);
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let crate_name = get_crate_name(&args);
     let src_dst = get_src_dst(&args);
     let field_suppress = suppress_unused_fields(&args);
     let struct_extensions = if args.struct_extensions {
@@ -420,14 +430,14 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             }
             // Only structs are eligible being marked zero-copy, so only the struct
             // impl needs the repr.
-            impl_struct(&args, fields, &repr)
+            impl_struct(&args, fields, &repr, &crate_name)
         }
         Data::Enum(v) => {
             let enum_ident = match &args.from {
                 Some(from) => from,
                 None => &parse_quote!(Self),
             };
-            impl_enum(enum_ident, v, args.tag_encoding.as_ref())
+            impl_enum(enum_ident, v, args.tag_encoding.as_ref(), &crate_name)
         }
     };
 
@@ -444,13 +454,13 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
         {
             let field_tys = fields.iter().map(|field| &field.ty);
             let mut bounds = Punctuated::new();
-            bounds.push(parse_quote!(IsTrue));
+            bounds.push(parse_quote!(__WincodeIsTrue));
             let no_pad_predicate = WherePredicate::Type(PredicateType {
                 // Workaround for https://github.com/rust-lang/rust/issues/48214.
                 lifetimes: Some(parse_quote!(for<'_wincode_internal>)),
                 // Types are only zero-copy if they do not have any padding.
                 bounded_ty: parse_quote!(
-                    Assert<
+                    __WincodeAssert<
                         {
                             #(core::mem::size_of::<#field_tys>())+* == core::mem::size_of::<#ident>()
                         },
@@ -462,7 +472,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
 
             let field_targets = fields.iter().map(|field| field.target_resolved());
             let mut bounds = Punctuated::new();
-            bounds.push(parse_quote!(ZeroCopy<WincodeConfig>));
+            bounds.push(parse_quote!(#crate_name::config::ZeroCopy<__WincodeConfig>));
             let zero_copy_predicate = field_targets.into_iter().map(|target| {
                 WherePredicate::Type(PredicateType {
                     // Workaround for https://github.com/rust-lang/rust/issues/48214.
@@ -476,7 +486,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
 
             let predicates = zero_copy_predicate.chain(core::iter::once(no_pad_predicate));
             let mut generics = args.generics.clone();
-            append_config(&mut generics);
+            append_config(&mut generics, &crate_name);
             let (impl_generics, _, _) = generics.split_for_impl();
             let (_, ty_generics, where_clause) = args.generics.split_for_impl();
             let mut where_clause = where_clause.cloned();
@@ -494,10 +504,10 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
 
             quote! {
                 // Ugly, but functional.
-                struct Assert<const B: bool>;
-                trait IsTrue {}
-                impl IsTrue for Assert<true> {}
-                unsafe impl #impl_generics ZeroCopy<WincodeConfig> for #ident #ty_generics #where_clause {}
+                struct __WincodeAssert<const B: bool>;
+                trait __WincodeIsTrue {}
+                impl __WincodeIsTrue for __WincodeAssert<true> {}
+                unsafe impl #impl_generics #crate_name::config::ZeroCopy<__WincodeConfig> for #ident #ty_generics #where_clause {}
             }
         }
         _ => quote!(),
@@ -505,19 +515,16 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
 
     Ok(quote! {
         const _: () = {
-            use core::{ptr, mem::{self, MaybeUninit}};
-            use #crate_name::{SchemaRead, ReadResult, tag_encoding::TagEncoding, TypeMeta, io::Reader, error, config::{Config, DefaultConfig, ZeroCopy}};
-
             #zero_copy_impl
 
-            unsafe impl #impl_generics SchemaRead<'de, WincodeConfig> for #ident #ty_generics #where_clause {
+            unsafe impl #impl_generics #crate_name::SchemaRead<'de, __WincodeConfig> for #ident #ty_generics #where_clause {
                 type Dst = #src_dst;
 
                 #[allow(clippy::arithmetic_side_effects)]
-                const TYPE_META: TypeMeta = #type_meta_impl;
+                const TYPE_META: #crate_name::TypeMeta = #type_meta_impl;
 
                 #[inline]
-                fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+                fn read(mut reader: impl #crate_name::io::Reader<'de>, dst: &mut ::core::mem::MaybeUninit<Self::Dst>) -> #crate_name::ReadResult<()> {
                     #read_impl
                     Ok(())
                 }

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -14,7 +14,7 @@ use {
     proc_macro2::TokenStream,
     quote::quote,
     syn::{
-        DeriveInput, GenericParam, Generics, PredicateType, Token, Type, WherePredicate,
+        DeriveInput, GenericParam, Generics, Path, PredicateType, Token, Type, WherePredicate,
         parse_quote, punctuated::Punctuated,
     },
 };
@@ -22,13 +22,14 @@ use {
 fn impl_struct(
     fields: &Fields<Field>,
     repr: &StructRepr,
+    crate_name: &Path,
 ) -> (TokenStream, TokenStream, TokenStream) {
     if fields.is_empty() {
         return (
             quote! {Ok(0)},
             quote! {Ok(())},
             quote! {
-                TypeMeta::Static {
+                #crate_name::TypeMeta::Static {
                     size: 0,
                     zero_copy: true,
                 }
@@ -43,7 +44,7 @@ fn impl_struct(
         .filter_map(|(field, ident)| {
             if field.skip.is_none() {
                 let target = field.target_resolved();
-                let write = quote! { <#target as SchemaWrite<WincodeConfig>>::write(writer.by_ref(), &src.#ident)?; };
+                let write = quote! { <#target as #crate_name::SchemaWrite<__WincodeConfig>>::write(#crate_name::io::Writer::by_ref(&mut writer), &src.#ident)?; };
                 size_count_idents.push(ident);
                 Some(write)
             } else {
@@ -52,31 +53,31 @@ fn impl_struct(
         })
         .collect::<Vec<_>>();
 
-    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaWrite, repr);
+    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaWrite, repr, crate_name);
 
     (
         quote! {
-            if let TypeMeta::Static { size, .. } = <Self as SchemaWrite<WincodeConfig>>::TYPE_META {
+            if let #crate_name::TypeMeta::Static { size, .. } = <Self as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META {
                 return Ok(size);
             }
             let mut total = 0usize;
             #(
-                total += <#target as SchemaWrite<WincodeConfig>>::size_of(&src.#size_count_idents)?;
+                total += <#target as #crate_name::SchemaWrite<__WincodeConfig>>::size_of(&src.#size_count_idents)?;
             )*
             Ok(total)
         },
         quote! {
-            match <Self as SchemaWrite<WincodeConfig>>::TYPE_META {
-                TypeMeta::Static { size, .. } => {
+            match <Self as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META {
+                #crate_name::TypeMeta::Static { size, .. } => {
                     // SAFETY: `size` is the serialized size of the struct, which is the sum
                     // of the serialized sizes of the fields.
                     // Calling `write` on each field will write exactly `size` bytes,
                     // fully initializing the trusted window.
-                    let mut writer = unsafe { writer.as_trusted_for(size) }?;
+                    let mut writer = unsafe { #crate_name::io::Writer::as_trusted_for(&mut writer, size) }?;
                     #(#writes)*
-                    writer.finish()?;
+                    #crate_name::io::Writer::finish(&mut writer)?;
                 }
-                TypeMeta::Dynamic => {
+                #crate_name::TypeMeta::Dynamic => {
                     #(#writes)*
                 }
             }
@@ -90,16 +91,21 @@ fn impl_enum(
     enum_ident: &Type,
     variants: &[Variant],
     tag_encoding_override: Option<&Type>,
+    crate_name: &Path,
 ) -> (TokenStream, TokenStream, TokenStream) {
     if variants.is_empty() {
-        return (quote! {Ok(0)}, quote! {Ok(())}, quote! {TypeMeta::Dynamic});
+        return (
+            quote! {Ok(0)},
+            quote! {Ok(())},
+            quote! {#crate_name::TypeMeta::Dynamic},
+        );
     }
     let mut size_of_impl = Vec::with_capacity(variants.len());
     let mut write_impl = Vec::with_capacity(variants.len());
     let default_tag_encoding = default_tag_encoding();
     let tag_encoding = tag_encoding_override.unwrap_or(&default_tag_encoding);
 
-    let type_meta_impl = variants.type_meta_impl(TraitImpl::SchemaWrite, tag_encoding);
+    let type_meta_impl = variants.type_meta_impl(TraitImpl::SchemaWrite, tag_encoding, crate_name);
 
     for (i, variant) in variants.iter().enumerate() {
         let variant_ident = &variant.ident;
@@ -111,19 +117,19 @@ fn impl_enum(
         {
             (
                 quote! {
-                    <#tag_encoding as SchemaWrite<WincodeConfig>>::size_of(&#discriminant)?
+                    <#tag_encoding as #crate_name::SchemaWrite<__WincodeConfig>>::size_of(&#discriminant)?
                 },
                 quote! {
-                    <#tag_encoding as SchemaWrite<WincodeConfig>>::write(writer.by_ref(), &#discriminant)?
+                    <#tag_encoding as #crate_name::SchemaWrite<__WincodeConfig>>::write(#crate_name::io::Writer::by_ref(&mut writer), &#discriminant)?
                 },
             )
         } else {
             (
                 quote! {
-                    WincodeConfig::TagEncoding::size_of_from_u32(#discriminant)?
+                    <__WincodeConfig::TagEncoding as #crate_name::tag_encoding::TagEncoding<__WincodeConfig>>::size_of_from_u32(#discriminant)?
                 },
                 quote! {
-                    WincodeConfig::TagEncoding::write_from_u32(writer.by_ref(), #discriminant)?
+                    <__WincodeConfig::TagEncoding as #crate_name::tag_encoding::TagEncoding<__WincodeConfig>>::write_from_u32(#crate_name::io::Writer::by_ref(&mut writer), #discriminant)?
                 },
             )
         };
@@ -139,7 +145,7 @@ fn impl_enum(
                         if field.skip.is_none() {
                             let target = field.target_resolved();
                             let write = quote! {
-                                <#target as SchemaWrite<WincodeConfig>>::write(writer.by_ref(), #ident)?;
+                                <#target as #crate_name::SchemaWrite<__WincodeConfig>>::write(#crate_name::io::Writer::by_ref(&mut writer), #ident)?;
                             };
                             pattern_fragments.push(quote! { #ident });
                             size_count_idents.push(ident);
@@ -169,18 +175,18 @@ fn impl_enum(
 
                 let static_targets = unskipped_targets
                     .clone()
-                    .map(|target| quote! {<#target as SchemaWrite<WincodeConfig>>::TYPE_META})
+                    .map(|target| quote! {<#target as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META})
                     .collect::<Vec<_>>();
                 (
                     quote! {
                         #match_case => {
-                            if let TypeMeta::Static { size, .. } = TypeMeta::join_types([<#tag_encoding as SchemaWrite<WincodeConfig>>::TYPE_META #(,#static_targets)*]) {
+                            if let #crate_name::TypeMeta::Static { size, .. } = #crate_name::TypeMeta::join_types([<#tag_encoding as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META #(,#static_targets)*]) {
                                 return Ok(size);
                             }
 
                             let mut total = #size_of_discriminant;
                             #(
-                                total += <#unskipped_targets as SchemaWrite<WincodeConfig>>::size_of(#size_count_idents)?;
+                                total += <#unskipped_targets as #crate_name::SchemaWrite<__WincodeConfig>>::size_of(#size_count_idents)?;
                             )*
 
                             Ok(total)
@@ -188,15 +194,15 @@ fn impl_enum(
                     },
                     quote! {
                         #match_case => {
-                            if let TypeMeta::Static { size: summed_sizes, .. } = TypeMeta::join_types([<#tag_encoding as SchemaWrite<WincodeConfig>>::TYPE_META #(,#static_targets)*]) {
+                            if let #crate_name::TypeMeta::Static { size: summed_sizes, .. } = #crate_name::TypeMeta::join_types([<#tag_encoding as #crate_name::SchemaWrite<__WincodeConfig>>::TYPE_META #(,#static_targets)*]) {
                                 // SAFETY: `summed_sizes` is the sum of the static sizes of the fields + the discriminant size,
                                 // which is the serialized size of the variant.
                                 // Writing the discriminant and then calling `write` on each field will write
                                 // exactly `summed_sizes` bytes, fully initializing the trusted window.
-                                let mut writer = unsafe { writer.as_trusted_for(summed_sizes) }?;
+                                let mut writer = unsafe { #crate_name::io::Writer::as_trusted_for(&mut writer, summed_sizes) }?;
                                 #write_discriminant;
                                 #(#write)*
-                                writer.finish()?;
+                                #crate_name::io::Writer::finish(&mut writer)?;
                                 return Ok(());
                             }
 
@@ -244,18 +250,18 @@ fn impl_enum(
     )
 }
 
-fn append_config(generics: &mut Generics) {
-    generics
-        .params
-        .push(GenericParam::Type(parse_quote!(WincodeConfig: Config)));
+fn append_config(generics: &mut Generics, crate_name: &Path) {
+    generics.params.push(GenericParam::Type(
+        parse_quote!(__WincodeConfig: #crate_name::config::Config),
+    ));
 }
 
-fn append_where_clause(generics: &mut Generics) {
+fn append_where_clause(generics: &mut Generics, crate_name: &Path) {
     let mut predicates: Punctuated<WherePredicate, Token![,]> = Punctuated::new();
     for param in generics.type_params() {
         let ident = &param.ident;
         let mut bounds = Punctuated::new();
-        bounds.push(parse_quote!(SchemaWrite<WincodeConfig, Src = #ident>));
+        bounds.push(parse_quote!(#crate_name::SchemaWrite<__WincodeConfig, Src = #ident>));
 
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
@@ -272,21 +278,21 @@ fn append_where_clause(generics: &mut Generics) {
     where_clause.predicates.extend(predicates);
 }
 
-fn append_generics(generics: &Generics) -> Generics {
+fn append_generics(generics: &Generics, crate_name: &Path) -> Generics {
     let mut generics = generics.clone();
-    append_where_clause(&mut generics);
-    append_config(&mut generics);
+    append_where_clause(&mut generics, crate_name);
+    append_config(&mut generics, crate_name);
     generics
 }
 
 pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let repr = extract_repr(&input, "SchemaWrite")?;
     let args = SchemaArgs::from_derive_input(&input)?;
-    let appended_generics = append_generics(&args.generics);
+    let crate_name = get_crate_name(&args);
+    let appended_generics = append_generics(&args.generics, &crate_name);
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let crate_name = get_crate_name(&args);
     let src_dst = get_src_dst(&args);
     let field_suppress = suppress_unused_fields(&args);
     let zero_copy_asserts = assert_zero_copy(&args, &repr)?;
@@ -298,33 +304,32 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             }
             // Only structs are eligible being marked zero-copy, so only the struct
             // impl needs the repr.
-            impl_struct(fields, &repr)
+            impl_struct(fields, &repr, &crate_name)
         }
         Data::Enum(v) => {
             let enum_ident = match &args.from {
                 Some(from) => from,
                 None => &parse_quote!(Self),
             };
-            impl_enum(enum_ident, v, args.tag_encoding.as_ref())
+            impl_enum(enum_ident, v, args.tag_encoding.as_ref(), &crate_name)
         }
     };
 
     Ok(quote! {
         const _: () = {
-            use #crate_name::{SchemaWrite, WriteResult, io::Writer, TypeMeta, config::Config, tag_encoding::TagEncoding};
-            unsafe impl #impl_generics #crate_name::SchemaWrite<WincodeConfig> for #ident #ty_generics #where_clause {
+            unsafe impl #impl_generics #crate_name::SchemaWrite<__WincodeConfig> for #ident #ty_generics #where_clause {
                 type Src = #src_dst;
 
                 #[allow(clippy::arithmetic_side_effects)]
-                const TYPE_META: TypeMeta = #type_meta_impl;
+                const TYPE_META: #crate_name::TypeMeta = #type_meta_impl;
 
                 #[inline]
-                fn size_of(src: &Self::Src) -> WriteResult<usize> {
+                fn size_of(src: &Self::Src) -> #crate_name::WriteResult<usize> {
                     #size_of_impl
                 }
 
                 #[inline]
-                fn write(mut writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+                fn write(mut writer: impl #crate_name::io::Writer, src: &Self::Src) -> #crate_name::WriteResult<()> {
                     #write_impl
                 }
             }

--- a/wincode-derive/src/uninit_builder.rs
+++ b/wincode-derive/src/uninit_builder.rs
@@ -30,7 +30,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         .params
         .push(GenericParam::Lifetime(parse_quote!('_wincode_inner)));
     builder_generics.params.push(GenericParam::Type(
-        parse_quote!(WincodeConfig: #crate_name::config::Config),
+        parse_quote!(__WincodeConfig: #crate_name::config::Config),
     ));
 
     let builder_dst = get_src_dst_fully_qualified(args);
@@ -68,7 +68,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
             #vis struct #builder_ident < #(#generic_lifetimes,)* #(#generic_const,)* #(#generic_type_params,)* > #where_clause {
                 inner: &'_wincode_inner mut core::mem::MaybeUninit<#builder_dst>,
                 init_set: #builder_bit_set_ty,
-                _config: core::marker::PhantomData<WincodeConfig>,
+                _config: core::marker::PhantomData<__WincodeConfig>,
             }
         }
     };
@@ -85,7 +85,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
                 if self.init_set & #bit_set_index != 0 {
                     // SAFETY: We are dropping an initialized field.
                     unsafe {
-                        ptr::drop_in_place(&raw mut (*dst_ptr).#field_ident);
+                        ::core::ptr::drop_in_place(&raw mut (*dst_ptr).#field_ident);
                     }
                 }
             }
@@ -110,7 +110,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
 
         quote! {
             impl #builder_impl_generics #builder_ident #builder_ty_generics #builder_where_clause {
-                #vis const fn from_maybe_uninit_mut(inner: &'_wincode_inner mut MaybeUninit<#builder_dst>) -> Self {
+                #vis const fn from_maybe_uninit_mut(inner: &'_wincode_inner mut ::core::mem::MaybeUninit<#builder_dst>) -> Self {
                     Self {
                         inner,
                         init_set: 0,
@@ -136,9 +136,9 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
                 /// to guarantee that the `MaybeUninit<T>` really is in an initialized state.
                 #[inline]
                 #vis unsafe fn into_assume_init_mut(mut self) -> &'_wincode_inner mut #builder_dst {
-                    let mut this = ManuallyDrop::new(self);
+                    let mut this = ::core::mem::ManuallyDrop::new(self);
                     // SAFETY: reference lives beyond the scope of the builder, and builder is forgotten.
-                    let inner = unsafe { ptr::read(&mut this.inner) };
+                    let inner = unsafe { ::core::ptr::read(&mut this.inner) };
                     // SAFETY: Caller asserts the `MaybeUninit<T>` is in an initialized state.
                     unsafe {
                         inner.assume_init_mut()
@@ -148,7 +148,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
                 /// Forget the builder, disabling the drop logic.
                 #[inline]
                 #vis const fn finish(self) {
-                    mem::forget(self);
+                    ::core::mem::forget(self);
                 }
             }
         }
@@ -171,14 +171,14 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         // not necessarily write to `Self` -- they write to `Self::Dst`, which isn't necessarily `Self`
         // (e.g., in the case of container types).
         let field_projection_type = if lifetimes.is_empty() {
-            quote!(<#ty as SchemaRead<'_, WincodeConfig>>::Dst)
+            quote!(<#ty as #crate_name::SchemaRead<'_, __WincodeConfig>>::Dst)
         } else {
             let lt = lifetimes[0];
             // Even though a type may have multiple distinct lifetimes, we force them to be uniform
             // for a `SchemaRead` cast because an implementation of `SchemaRead` must bind all lifetimes
             // to the lifetime of the reader (and will not be implemented over multiple distinct lifetimes).
             let ty = ty.with_lifetime(&lt.ident.to_string());
-            quote!(<#ty as SchemaRead<#lt, WincodeConfig>>::Dst)
+            quote!(<#ty as #crate_name::SchemaRead<#lt, __WincodeConfig>>::Dst)
         };
 
         // The bit index for the field.
@@ -190,7 +190,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         quote! {
             /// Get a mutable reference to the maybe uninitialized field.
             #[inline]
-            #vis const fn #uninit_mut_ident(&mut self) -> &mut MaybeUninit<#field_projection_type> {
+            #vis const fn #uninit_mut_ident(&mut self) -> &mut ::core::mem::MaybeUninit<#field_projection_type> {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
                 // - We return the field as `&mut MaybeUninit<#target>`, so
@@ -200,7 +200,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
 
             /// Get a reference to the maybe uninitialized field.
             #[inline]
-            #vis const fn #uninit_ref_ident(&self) -> &MaybeUninit<#field_projection_type> {
+            #vis const fn #uninit_ref_ident(&self) -> &::core::mem::MaybeUninit<#field_projection_type> {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
                 // - We return the field as `&MaybeUninit<#target>`, so
@@ -219,13 +219,13 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
 
             /// Read a value from the reader into the maybe uninitialized field.
             #[inline]
-            #vis fn #read_field_ident <'de>(&mut self, reader: impl Reader<'de>) -> ReadResult<&mut Self> {
+            #vis fn #read_field_ident <'de>(&mut self, reader: impl #crate_name::io::Reader<'de>) -> #crate_name::ReadResult<&mut Self> {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
                 // - We return the field as `&mut MaybeUninit<#target>`, so
                 //   the field is never exposed as initialized.
                 let proj = unsafe { &mut *(&raw mut (*self.inner.as_mut_ptr()).#ident).cast() };
-                <#target_reader_bound as SchemaRead<'de, WincodeConfig>>::read(reader, proj)?;
+                <#target_reader_bound as #crate_name::SchemaRead<'de, __WincodeConfig>>::read(reader, proj)?;
                 #set_index_bit
                 Ok(self)
             }
@@ -236,7 +236,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
             ///
             /// The caller must guarantee that the initializer function fully initializes the field.
             #[inline]
-            #vis unsafe fn #init_with_field_ident(&mut self, mut initializer: impl FnMut(&mut MaybeUninit<#field_projection_type>) -> ReadResult<()>) -> ReadResult<&mut Self> {
+            #vis unsafe fn #init_with_field_ident(&mut self, mut initializer: impl FnMut(&mut ::core::mem::MaybeUninit<#field_projection_type>) -> #crate_name::ReadResult<()>) -> #crate_name::ReadResult<&mut Self> {
                 initializer(self.#uninit_mut_ident())?;
                 #set_index_bit
                 Ok(self)
@@ -257,11 +257,6 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
 
     Ok(quote! {
         const _: () = {
-            use {
-                core::{mem::{MaybeUninit, ManuallyDrop, self}, ptr, marker::PhantomData},
-                #crate_name::{SchemaRead, ReadResult, TypeMeta, io::Reader, error, config::Config},
-            };
-
             #builder_drop_impl
             #builder_impl
 


### PR DESCRIPTION
## Summary
- fully qualify paths emitted by derive macros instead of importing them into generated scopes
- avoid generated helper names that collide with user-defined types

## Testing
- cargo test --workspace