### PR TITLE
ci: replace app-id with client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Set git config


### PR DESCRIPTION
#### Problem

`create-github-app-token` has deprecated `app-id` and recommends using `client-id` instead

#### Summary of Changes

replace app-id with client-id
