### PR TITLE
Bump wincode to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bincode",
  "bv",

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode"
-version = "0.5.4"
+version = "0.5.5"
 authors.workspace = true
 description = "Fast bincode de/serialization with placement initialization"
 repository.workspace = true
@@ -42,7 +42,7 @@ pastey = "0.2.2"
 smallvec = { version = "1.15.1", optional = true, default-features = false, features = ["const_generics"] }
 solana-short-vec = { version = "3.2.1", default-features = false, optional = true }
 thiserror = { version = "2.0.18", default-features = false }
-wincode-derive = { path = "../wincode-derive", version = "0.4.5", optional = true }
+wincode-derive = { path = "../wincode-derive", version = "0.4.6", optional = true }
 uuid = { version = "1.23.1", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Includes:
- https://github.com/anza-xyz/wincode/pull/320
- https://github.com/anza-xyz/wincode/pull/321

Pins `wincode-derive` to `0.4.6`