### PR TITLE
feat(derive): support wincode(with) on single field newtype variant

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -328,6 +328,10 @@ pub(crate) struct Variant {
     pub(crate) fields: Fields<Field>,
     #[darling(default)]
     pub(crate) tag: Option<Expr>,
+
+    /// Variant-level `SchemaRead` and `SchemaWrite` override for single-field (newtype) variants.
+    #[darling(default)]
+    pub(crate) with: Option<Type>,
 }
 
 impl Variant {
@@ -599,6 +603,46 @@ pub(crate) struct SchemaArgs {
     /// The path is emitted as written and resolved from the derive expansion site.
     #[darling(rename = "crate", default)]
     pub(crate) crate_path: Option<Path>,
+}
+
+impl SchemaArgs {
+    /// Push variant-level attributes down onto each variant's sole field, returning the updated
+    /// args.
+    ///
+    /// Currently this handles `with`: a `with` placed on an enum variant is a convenience for
+    /// single-field (newtype) variants, equivalent to annotating the inner field. Pushing it down
+    /// onto that field means the rest of the derive (which only reads field-level `with`) needs no
+    /// special casing.
+    ///
+    /// Errors if a variant carrying such an attribute does not have exactly one field, or if both
+    /// the variant and its field specify `with`.
+    pub(crate) fn push_down_variant_attributes(mut self) -> Result<Self> {
+        let Data::Enum(variants) = &mut self.data else {
+            return Ok(self);
+        };
+        for variant in variants {
+            let Some(with) = variant.with.take() else {
+                continue;
+            };
+            let [field] = variant.fields.fields.as_mut_slice() else {
+                return Err(darling::Error::custom(
+                    "`with` on an enum variant is shorthand for annotating its single field, so \
+                     it requires a variant with exactly one field. Unlike serde, it is not a \
+                     whole-variant override; annotate the individual fields instead",
+                )
+                .with_span(&variant.ident));
+            };
+            if field.with.is_some() {
+                return Err(darling::Error::custom(
+                    "`with` is specified on both the variant and its field; it is shorthand for \
+                     the field, so specify it in only one place",
+                )
+                .with_span(&variant.ident));
+            }
+            field.with = Some(with);
+        }
+        Ok(self)
+    }
 }
 
 /// Configuration for zero-copy assertions.

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -396,7 +396,7 @@ fn append_generics(
 
 pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let repr = extract_repr(&input, "SchemaRead")?;
-    let args = SchemaArgs::from_derive_input(&input)?;
+    let args = SchemaArgs::from_derive_input(&input)?.push_down_variant_attributes()?;
     let crate_name = get_crate_name(&args);
     let appended_generics = append_generics(&args.generics, &args.data, &crate_name);
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -287,7 +287,7 @@ fn append_generics(generics: &Generics, crate_name: &Path) -> Generics {
 
 pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let repr = extract_repr(&input, "SchemaWrite")?;
-    let args = SchemaArgs::from_derive_input(&input)?;
+    let args = SchemaArgs::from_derive_input(&input)?.push_down_variant_attributes()?;
     let crate_name = get_crate_name(&args);
     let appended_generics = append_generics(&args.generics, &crate_name);
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -34,3 +34,33 @@
 /// # }
 /// ```
 fn static_derive_requires_static_input() {}
+
+/// A variant-level `with` requires the variant to have exactly one field.
+///
+/// ```compile_fail
+/// # #[cfg(feature = "derive")] {
+/// use wincode::{SchemaRead, SchemaWrite};
+///
+/// #[derive(SchemaRead, SchemaWrite)]
+/// enum Foo {
+///     #[wincode(with = "Bar")]
+///     Bar(u32, u32),
+/// }
+/// # }
+/// ```
+fn variant_with_requires_single_field() {}
+
+/// A `with` cannot be specified on both a variant and its field.
+///
+/// ```compile_fail
+/// # #[cfg(feature = "derive")] {
+/// use wincode::{SchemaRead, SchemaWrite};
+///
+/// #[derive(SchemaRead, SchemaWrite)]
+/// enum Foo {
+///     #[wincode(with = "Bar")]
+///     Bar(#[wincode(with = "Baz")] u32),
+/// }
+/// # }
+/// ```
+fn variant_with_conflicts_with_field_with() {}

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -44,6 +44,29 @@
 //! assert_eq!(my_struct, MyStruct::deserialize(&bytes).unwrap());
 //! # }
 //! ```
+//!
+//! # The `with` attribute on enum variants
+//!
+//! `#[wincode(with = "...")]` may also be placed on a single-field enum variant, as a convenience
+//! for newtype-style variants. It is exactly equivalent to annotating the inner field:
+//!
+//! ```
+//! # #[cfg(all(feature = "alloc", feature = "derive"))] {
+//! # use wincode::{len::UseIntLen, containers};
+//! # use wincode_derive::{SchemaWrite, SchemaRead};
+//! #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+//! enum Message {
+//!     #[wincode(with = "containers::Vec<u32, UseIntLen<u16>>")]
+//!     Ids(Vec<u32>),
+//!     Empty,
+//! }
+//! # }
+//! ```
+//!
+//! Note this differs from serde's `#[serde(with = ...)]` on a variant, which is a whole-variant
+//! override accepting any number of fields. In wincode, `with` is a *type* override for a single
+//! value, so a variant-level `with` is simply shorthand for its sole field and requires the
+//! variant to have exactly one field.
 use {
     crate::{
         config::{self, ConfigCore, DefaultConfig},
@@ -1952,6 +1975,40 @@ mod tests {
                 Enum::C => 13,
             };
             prop_assert_eq!(&int.to_le_bytes(), &serialized[..4]);
+        });
+    }
+
+    #[test]
+    fn enum_variant_level_with() {
+        // A `with` placed on a single-field variant is lowered onto the inner field, and is
+        // exactly equivalent to annotating the field directly.
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, proptest_derive::Arbitrary)]
+        #[wincode(internal)]
+        enum Outer {
+            #[wincode(with = "containers::Vec<u32, crate::len::UseIntLen<u16>>")]
+            Bar(Vec<u32>),
+            Baz,
+        }
+
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+        #[wincode(internal)]
+        enum Inner {
+            Bar(#[wincode(with = "containers::Vec<u32, crate::len::UseIntLen<u16>>")] Vec<u32>),
+            Baz,
+        }
+
+        // The variant-level annotation produces identical bytes to the field-level annotation,
+        // and a `u16` length prefix rather than bincode's default `u64`.
+        let val = Outer::Bar(vec![1, 2, 3]);
+        let serialized = serialize(&val).unwrap();
+        // 4 (u32 discriminant) + 2 (u16 len) + 12 (3 * u32) = 18 bytes.
+        assert_eq!(serialized.len(), 18);
+        assert_eq!(serialized, serialize(&Inner::Bar(vec![1, 2, 3])).unwrap());
+
+        proptest!(proptest_cfg(), |(e: Outer)| {
+            let serialized = serialize(&e).unwrap();
+            let deserialized: Outer = deserialize(&serialized).unwrap();
+            prop_assert_eq!(deserialized, e);
         });
     }
 


### PR DESCRIPTION
Allows the `with` attribute to be placed directly on a single-field enum variant, as shorthand for annotating the inner field:

```rust
enum Message {
    #[wincode(with = "containers::Vec<u32, UseIntLen<u16>>")]
    Ids(Vec<u32>),
    Empty,
}
```

This is exactly equivalent to `Ids(#[wincode(with = "...")] Vec<u32>)` — it produces identical bytes and applies the same encoding override. Previously the attribute was only accepted on fields; on a variant it errored with `Unknown field: with`.

#### Difference from serde

serde also accepts `#[serde(with = ...)]` on variants, but it means something different and is more permissive:

- **serde** treats it as a *whole-variant override*: a pair of functions operating over *all* the variant's fields collectively (any arity — unit, tuple, struct). It exists precisely to customize multi-field variants.
- **wincode** `with` is a *type* override for a single value, not a function. So on a variant it can only be sugar for the single inner field, and multi-field variants are rejected.

The error message and module docs call this distinction out explicitly so users coming from serde aren't surprised by the single-field restriction.