### PR TITLE
ci: pin gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,5 @@ updates:
       time: "08:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,12 @@ jobs:
     name: rustfmt, clippy & miri (nightly)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: ${{ env.NIGHTLY }}
           components: rustfmt, clippy, miri, rust-src
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rustflags: ""
       - name: rustfmt (check)
         run: cargo +${{ env.NIGHTLY }} fmt --all -- --check
       - name: clippy (deny warnings)
@@ -36,13 +34,11 @@ jobs:
     name: tests (MSRV)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: 1.89.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rustflags: ""
       - name: tests
         run: cargo test --all-features --all-targets --no-fail-fast --workspace
       - name: test alloc
@@ -58,13 +54,11 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: 1.89.0
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: 1.89.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rustflags: ""
       - name: install cargo-deny
         run: cargo install cargo-deny --version 0.19.0 --locked
       - name: cargo deny
@@ -74,17 +68,15 @@ jobs:
     name: fuzz smoke check (nightly)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: nightly
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rustflags: ""
       - name: rustfmt (fuzz)
         run: cargo +nightly fmt --manifest-path fuzz/Cargo.toml -- --check
       - name: clippy (fuzz)
         run: cargo +nightly clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
-      - uses: dtolnay/install@cargo-fuzz
+      - uses: dtolnay/install@d0dc46e85ffd2c174b5ac0489e17f95dae84fa5a # cargo-fuzz
       - run: cargo +nightly fuzz run roundtrip --no-trace-compares -- -max_len=$((5 << 20)) -max_total_time=60

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,17 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: fuzz
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: nightly
-
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
+          rustflags: ""
 
       - uses: dtolnay/install@d0dc46e85ffd2c174b5ac0489e17f95dae84fa5a # cargo-fuzz
       - run: cargo +nightly fuzz build --no-trace-compares

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       ref: ${{ steps.meta.outputs.ref }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
@@ -82,7 +82,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.CLIENT_ID }}
@@ -98,7 +98,7 @@ jobs:
           APP_ID: ${{ vars.APP_ID }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
@@ -116,11 +116,11 @@ jobs:
           CRATE_NAME: ${{ inputs.crate }}
 
       - name: Generate SLSA provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: target/package/*.crate
 
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 
       - run: cargo publish -p "${CRATE_NAME}"


### PR DESCRIPTION
Continuation of my gh action pinning, so pinned all actions across our workflows to commit SHAs. While in there:

- Swapped `dtolnay/rust-toolchain@master` → `actions-rust-lang/setup-rust-toolchain`. It's properly versioned (so Dependabot bumps it like everything else, instead of us tracking a raw `master` commit), and it bundles `Swatinem/rust-cache`, so each `toolchain` + `cache` pair collapses into one step.
- Added a 7-day `cooldown` to the `github-actions` Dependabot section, matching agave.

