### PR TITLE
Only add trait bounds for type params that are actually used

### DIFF
--- a/wincode-derive/Cargo.toml
+++ b/wincode-derive/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 darling = "0.23.0"
 proc-macro2.workspace = true
 quote.workspace = true
-syn = { version = "2.0.117", features = ["visit-mut", "visit"] }
+syn = { version = "2.0.117", features = ["extra-traits", "visit-mut", "visit"] }

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -7,7 +7,7 @@ use {
     quote::{ToTokens as _, quote},
     std::{
         borrow::Cow,
-        collections::VecDeque,
+        collections::{HashSet, VecDeque},
         fmt::{self, Display},
     },
     syn::{
@@ -846,7 +846,7 @@ impl Visit<'_> for HasLifetime {
 }
 
 struct HasTypeParam<'a> {
-    type_params: &'a std::collections::HashSet<&'a Ident>,
+    type_params: &'a HashSet<&'a Ident>,
     found: bool,
 }
 
@@ -864,21 +864,71 @@ pub(crate) struct GenericField {
     pub(crate) ty: Type,
 }
 
+/// Find fields that mention one of the generic type parameters on the derived type.
+///
+/// The returned `GenericField` keeps two types:
+/// - `target`: the type whose `SchemaRead`/`SchemaWrite` impl will be called
+/// - `ty`: the actual type stored in the field
+///
+/// This is specifically based on the _fields_, not just the generic parameter list.
+/// For example, if a type parameter is only used to name an associated type, we return the
+/// associated type that is actually stored:
+///
+/// ```ignore
+/// trait HasValue {
+///     type Value;
+/// }
+///
+/// struct Wrapper<T: HasValue> {
+///     value: T::Value,
+/// }
+///
+/// // yields:
+/// // target = T::Value
+/// // ty     = T::Value
+///
+/// // does not yield T
+/// ```
+///
+/// The returned `GenericField` keeps both the schema type and the underlying field type.
+/// Usually those are the same:
+///
+/// ```ignore
+/// struct Wrapper<T> {
+///     value: T,
+/// }
+///
+/// // target = T
+/// // ty     = T
+/// ```
+///
+/// They differ when a field uses `#[wincode(with = ...)]`. In that case the
+/// generated code calls `SchemaRead`/`SchemaWrite` on the adapter type, but the
+/// adapter's `Src`/`Dst` must match the real field type:
+///
+/// ```ignore
+/// struct Wrapper<T> {
+///     #[wincode(with = "containers::Vec<_, BincodeLen>")]
+///     values: Vec<T>,
+/// }
+///
+/// // target = containers::Vec<T, BincodeLen>
+/// // ty     = Vec<T>
+/// ```
 pub(crate) fn generic_field_types(
     data: &Data<Variant, Field>,
     generics: &Generics,
-) -> std::collections::HashSet<GenericField> {
-    let type_params: std::collections::HashSet<&Ident> =
-        generics.type_params().map(|p| &p.ident).collect();
+) -> HashSet<GenericField> {
+    let type_params: HashSet<&Ident> = generics.type_params().map(|p| &p.ident).collect();
     if type_params.is_empty() {
-        return std::collections::HashSet::new();
+        return HashSet::new();
     }
 
     fn visit<'a>(
         fields: impl Iterator<Item = &'a Field>,
-        type_params: &std::collections::HashSet<&Ident>,
-    ) -> std::collections::HashSet<GenericField> {
-        let mut result = std::collections::HashSet::new();
+        type_params: &HashSet<&Ident>,
+    ) -> HashSet<GenericField> {
+        let mut result = HashSet::new();
         for field in fields {
             if field.skip.is_some() {
                 continue;

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -845,12 +845,12 @@ impl Visit<'_> for HasLifetime {
     }
 }
 
-struct HasTypeParam {
-    type_params: std::collections::HashSet<Ident>,
+struct HasTypeParam<'a> {
+    type_params: &'a std::collections::HashSet<&'a Ident>,
     found: bool,
 }
 
-impl Visit<'_> for HasTypeParam {
+impl Visit<'_> for HasTypeParam<'_> {
     fn visit_ident(&mut self, i: &Ident) {
         if self.type_params.contains(i) {
             self.found = true;
@@ -858,36 +858,51 @@ impl Visit<'_> for HasTypeParam {
     }
 }
 
-pub(crate) fn generic_field_types(data: &Data<Variant, Field>, generics: &Generics) -> Vec<Type> {
-    let type_params: std::collections::HashSet<Ident> =
-        generics.type_params().map(|p| p.ident.clone()).collect();
+#[derive(Hash, PartialEq, Eq)]
+pub(crate) struct GenericField {
+    pub(crate) target: Type,
+    pub(crate) ty: Type,
+}
+
+pub(crate) fn generic_field_types(
+    data: &Data<Variant, Field>,
+    generics: &Generics,
+) -> std::collections::HashSet<GenericField> {
+    let type_params: std::collections::HashSet<&Ident> =
+        generics.type_params().map(|p| &p.ident).collect();
     if type_params.is_empty() {
-        return Vec::new();
+        return std::collections::HashSet::new();
     }
-    let fields: Vec<&Field> = match data {
-        Data::Struct(fields) => fields.iter().collect(),
-        Data::Enum(variants) => variants.iter().flat_map(|v| v.fields.iter()).collect(),
-    };
-    let mut result = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for field in &fields {
-        if field.skip.is_some() {
-            continue;
-        }
-        let target = field.target_resolved();
-        let mut visitor = HasTypeParam {
-            type_params: type_params.clone(),
-            found: false,
-        };
-        visitor.visit_type(&target);
-        if visitor.found {
-            let key = target.to_token_stream().to_string();
-            if seen.insert(key) {
-                result.push(target);
+
+    fn visit<'a>(
+        fields: impl Iterator<Item = &'a Field>,
+        type_params: &std::collections::HashSet<&Ident>,
+    ) -> std::collections::HashSet<GenericField> {
+        let mut result = std::collections::HashSet::new();
+        for field in fields {
+            if field.skip.is_some() {
+                continue;
+            }
+            let target = field.target_resolved();
+            let mut visitor = HasTypeParam {
+                type_params,
+                found: false,
+            };
+            visitor.visit_type(&target);
+            if visitor.found {
+                result.insert(GenericField {
+                    target,
+                    ty: field.ty.clone(),
+                });
             }
         }
+        result
     }
-    result
+
+    match data {
+        Data::Struct(fields) => visit(fields.iter(), &type_params),
+        Data::Enum(variants) => visit(variants.iter().flat_map(|v| v.fields.iter()), &type_params),
+    }
 }
 
 #[cfg(test)]

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -864,57 +864,25 @@ pub(crate) struct GenericField {
     pub(crate) ty: Type,
 }
 
-/// Find fields that mention one of the generic type parameters on the derived type.
+/// Find fields whose types mention a generic type parameter of the derived type.
 ///
-/// The returned `GenericField` keeps two types:
+/// The returned [`GenericField`] keeps two types:
 /// - `target`: the type whose `SchemaRead`/`SchemaWrite` impl will be called
 /// - `ty`: the actual type stored in the field
 ///
-/// This is specifically based on the _fields_, not just the generic parameter list.
-/// For example, if a type parameter is only used to name an associated type, we return the
-/// associated type that is actually stored:
-///
-/// ```ignore
-/// trait HasValue {
-///     type Value;
-/// }
-///
-/// struct Wrapper<T: HasValue> {
-///     value: T::Value,
-/// }
-///
-/// // yields:
-/// // target = T::Value
-/// // ty     = T::Value
-///
-/// // does not yield T
-/// ```
-///
-/// The returned `GenericField` keeps both the schema type and the underlying field type.
-/// Usually those are the same:
-///
-/// ```ignore
-/// struct Wrapper<T> {
-///     value: T,
-/// }
-///
-/// // target = T
-/// // ty     = T
-/// ```
-///
-/// They differ when a field uses `#[wincode(with = ...)]`. In that case the
-/// generated code calls `SchemaRead`/`SchemaWrite` on the adapter type, but the
-/// adapter's `Src`/`Dst` must match the real field type:
+/// `target` will be the same as `ty`, except for when a field uses `#[wincode(with = ...)]`:
 ///
 /// ```ignore
 /// struct Wrapper<T> {
 ///     #[wincode(with = "containers::Vec<_, BincodeLen>")]
 ///     values: Vec<T>,
 /// }
-///
 /// // target = containers::Vec<T, BincodeLen>
 /// // ty     = Vec<T>
 /// ```
+///
+/// When this happens, the generated code calls `SchemaRead`/`SchemaWrite` on the adapter type,
+/// but the adapter's `Src`/`Dst` must match the real field type.
 pub(crate) fn generic_field_types(
     data: &Data<Variant, Field>,
     generics: &Generics,

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -845,6 +845,51 @@ impl Visit<'_> for HasLifetime {
     }
 }
 
+struct HasTypeParam {
+    type_params: std::collections::HashSet<Ident>,
+    found: bool,
+}
+
+impl Visit<'_> for HasTypeParam {
+    fn visit_ident(&mut self, i: &Ident) {
+        if self.type_params.contains(i) {
+            self.found = true;
+        }
+    }
+}
+
+pub(crate) fn generic_field_types(data: &Data<Variant, Field>, generics: &Generics) -> Vec<Type> {
+    let type_params: std::collections::HashSet<Ident> =
+        generics.type_params().map(|p| p.ident.clone()).collect();
+    if type_params.is_empty() {
+        return Vec::new();
+    }
+    let fields: Vec<&Field> = match data {
+        Data::Struct(fields) => fields.iter().collect(),
+        Data::Enum(variants) => variants.iter().flat_map(|v| v.fields.iter()).collect(),
+    };
+    let mut result = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for field in &fields {
+        if field.skip.is_some() {
+            continue;
+        }
+        let target = field.target_resolved();
+        let mut visitor = HasTypeParam {
+            type_params: type_params.clone(),
+            found: false,
+        };
+        visitor.visit_type(&target);
+        if visitor.found {
+            let key = target.to_token_stream().to_string();
+            if seen.insert(key) {
+                result.push(target);
+            }
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -2,9 +2,9 @@ use {
     crate::{
         assert_zero_copy::assert_zero_copy,
         common::{
-            Field, FieldsExt, SchemaArgs, StructRepr, TraitImpl, TypeExt, Variant, VariantsExt,
-            default_tag_encoding, extract_repr, generic_field_types, get_crate_name, get_src_dst,
-            get_src_dst_fully_qualified, suppress_unused_fields,
+            Field, FieldsExt, GenericField, SchemaArgs, StructRepr, TraitImpl, TypeExt, Variant,
+            VariantsExt, default_tag_encoding, extract_repr, generic_field_types, get_crate_name,
+            get_src_dst, get_src_dst_fully_qualified, suppress_unused_fields,
         },
         uninit_builder::impl_uninit_builder,
     },
@@ -321,13 +321,13 @@ fn append_config(generics: &mut Generics, crate_name: &Path) {
 fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>, crate_name: &Path) {
     let field_types = generic_field_types(data, generics);
     let mut predicates: Punctuated<WherePredicate, Token![,]> = Punctuated::new();
-    for ty in &field_types {
+    for GenericField { target, ty } in &field_types {
         let mut bounds = Punctuated::new();
         bounds.push(parse_quote!(#crate_name::SchemaRead<'de, __WincodeConfig, Dst = #ty>));
 
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
-            bounded_ty: parse_quote!(#ty),
+            bounded_ty: parse_quote!(#target),
             colon_token: parse_quote![:],
             bounds,
         }));

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -3,7 +3,7 @@ use {
         assert_zero_copy::assert_zero_copy,
         common::{
             Field, FieldsExt, SchemaArgs, StructRepr, TraitImpl, TypeExt, Variant, VariantsExt,
-            default_tag_encoding, extract_repr, get_crate_name, get_src_dst,
+            default_tag_encoding, extract_repr, generic_field_types, get_crate_name, get_src_dst,
             get_src_dst_fully_qualified, suppress_unused_fields,
         },
         uninit_builder::impl_uninit_builder,
@@ -319,15 +319,15 @@ fn append_config(generics: &mut Generics, crate_name: &Path) {
 }
 
 fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>, crate_name: &Path) {
+    let field_types = generic_field_types(data, generics);
     let mut predicates: Punctuated<WherePredicate, Token![,]> = Punctuated::new();
-    for param in generics.type_params() {
-        let ident = &param.ident;
+    for ty in &field_types {
         let mut bounds = Punctuated::new();
-        bounds.push(parse_quote!(#crate_name::SchemaRead<'de, __WincodeConfig, Dst = #ident>));
+        bounds.push(parse_quote!(#crate_name::SchemaRead<'de, __WincodeConfig, Dst = #ty>));
 
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
-            bounded_ty: parse_quote!(#ident),
+            bounded_ty: parse_quote!(#ty),
             colon_token: parse_quote![:],
             bounds,
         }));

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -3,7 +3,7 @@ use {
         assert_zero_copy::assert_zero_copy,
         common::{
             Field, FieldsExt, SchemaArgs, StructRepr, TraitImpl, Variant, VariantsExt,
-            default_tag_encoding, extract_repr, get_crate_name, get_src_dst,
+            default_tag_encoding, extract_repr, generic_field_types, get_crate_name, get_src_dst,
             suppress_unused_fields,
         },
     },
@@ -256,16 +256,16 @@ fn append_config(generics: &mut Generics, crate_name: &Path) {
     ));
 }
 
-fn append_where_clause(generics: &mut Generics, crate_name: &Path) {
+fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>, crate_name: &Path) {
+    let field_types = generic_field_types(data, generics);
     let mut predicates: Punctuated<WherePredicate, Token![,]> = Punctuated::new();
-    for param in generics.type_params() {
-        let ident = &param.ident;
+    for ty in &field_types {
         let mut bounds = Punctuated::new();
-        bounds.push(parse_quote!(#crate_name::SchemaWrite<__WincodeConfig, Src = #ident>));
+        bounds.push(parse_quote!(#crate_name::SchemaWrite<__WincodeConfig, Src = #ty>));
 
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
-            bounded_ty: parse_quote!(#ident),
+            bounded_ty: parse_quote!(#ty),
             colon_token: parse_quote![:],
             bounds,
         }));
@@ -278,9 +278,13 @@ fn append_where_clause(generics: &mut Generics, crate_name: &Path) {
     where_clause.predicates.extend(predicates);
 }
 
-fn append_generics(generics: &Generics, crate_name: &Path) -> Generics {
+fn append_generics(
+    generics: &Generics,
+    data: &Data<Variant, Field>,
+    crate_name: &Path,
+) -> Generics {
     let mut generics = generics.clone();
-    append_where_clause(&mut generics, crate_name);
+    append_where_clause(&mut generics, data, crate_name);
     append_config(&mut generics, crate_name);
     generics
 }
@@ -289,7 +293,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let repr = extract_repr(&input, "SchemaWrite")?;
     let args = SchemaArgs::from_derive_input(&input)?;
     let crate_name = get_crate_name(&args);
-    let appended_generics = append_generics(&args.generics, &crate_name);
+    let appended_generics = append_generics(&args.generics, &args.data, &crate_name);
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -2,9 +2,9 @@ use {
     crate::{
         assert_zero_copy::assert_zero_copy,
         common::{
-            Field, FieldsExt, SchemaArgs, StructRepr, TraitImpl, Variant, VariantsExt,
-            default_tag_encoding, extract_repr, generic_field_types, get_crate_name, get_src_dst,
-            suppress_unused_fields,
+            Field, FieldsExt, GenericField, SchemaArgs, StructRepr, TraitImpl, Variant,
+            VariantsExt, default_tag_encoding, extract_repr, generic_field_types, get_crate_name,
+            get_src_dst, suppress_unused_fields,
         },
     },
     darling::{
@@ -259,13 +259,13 @@ fn append_config(generics: &mut Generics, crate_name: &Path) {
 fn append_where_clause(generics: &mut Generics, data: &Data<Variant, Field>, crate_name: &Path) {
     let field_types = generic_field_types(data, generics);
     let mut predicates: Punctuated<WherePredicate, Token![,]> = Punctuated::new();
-    for ty in &field_types {
+    for GenericField { target, ty } in &field_types {
         let mut bounds = Punctuated::new();
         bounds.push(parse_quote!(#crate_name::SchemaWrite<__WincodeConfig, Src = #ty>));
 
         predicates.push(WherePredicate::Type(PredicateType {
             lifetimes: None,
-            bounded_ty: parse_quote!(#ty),
+            bounded_ty: parse_quote!(#target),
             colon_token: parse_quote![:],
             bounds,
         }));

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -4962,4 +4962,52 @@ mod tests {
         let deserialized: Both<MyData> = deserialize(&serialized).unwrap();
         assert_eq!(original, deserialized);
     }
+
+    #[test]
+    fn test_generic_type_with_container_adapter() {
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Clone)]
+        #[wincode(internal)]
+        struct Wrapper<T> {
+            #[wincode(with = "containers::Vec<_, BincodeLen>")]
+            inner: Vec<T>,
+        }
+
+        let original = Wrapper::<u8> {
+            inner: vec![1, 2, 3],
+        };
+        let serialized = serialize(&original).unwrap();
+        let deserialized: Wrapper<u8> = deserialize(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_generic_type_with_container_adapter_assoc() {
+        trait HasAssoc {
+            type Value: for<'de> SchemaRead<'de, DefaultConfig, Dst = Self::Value>
+                + SchemaWrite<DefaultConfig, Src = Self::Value>
+                + Clone
+                + core::fmt::Debug
+                + PartialEq;
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct UsesU64;
+        impl HasAssoc for UsesU64 {
+            type Value = u64;
+        }
+
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Clone)]
+        #[wincode(internal)]
+        struct Wrapper<T: HasAssoc> {
+            #[wincode(with = "containers::Vec<_, BincodeLen>")]
+            inner: Vec<T::Value>,
+        }
+
+        let original = Wrapper::<UsesU64> {
+            inner: vec![42, 67],
+        };
+        let serialized = serialize(&original).unwrap();
+        let deserialized: Wrapper<UsesU64> = deserialize(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
 }

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -4879,4 +4879,87 @@ mod tests {
 
         assert_eq!(serialized, expected);
     }
+
+    // test using a struct that receives a T but only stores a T::SomeType
+    #[test]
+    fn test_generic_associated_type_only() {
+        trait HasAssoc {
+            type Value: for<'de> SchemaRead<'de, DefaultConfig, Dst = Self::Value>
+                + SchemaWrite<DefaultConfig, Src = Self::Value>
+                + Clone
+                + core::fmt::Debug
+                + PartialEq;
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct UsesU64;
+        impl HasAssoc for UsesU64 {
+            type Value = u64;
+        }
+
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Clone)]
+        #[wincode(internal)]
+        struct Wrapper<T: HasAssoc> {
+            inner: T::Value,
+        }
+
+        let original = Wrapper::<UsesU64> { inner: 42u64 };
+        let serialized = serialize(&original).unwrap();
+        let deserialized: Wrapper<UsesU64> = deserialize(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    // test using a struct that receives a T and stores it
+    #[test]
+    fn test_generic_direct_type() {
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Clone)]
+        #[wincode(internal)]
+        struct Wrapper<T> {
+            inner: T,
+        }
+
+        let original = Wrapper::<String> {
+            inner: "hello".into(),
+        };
+        let serialized = serialize(&original).unwrap();
+        let deserialized: Wrapper<String> = deserialize(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    // test using a struct that receives a T and stores it plus the T::SomeType
+    #[test]
+    fn test_generic_direct_and_associated_type() {
+        trait HasAssoc {
+            type Extra: for<'de> SchemaRead<'de, DefaultConfig, Dst = Self::Extra>
+                + SchemaWrite<DefaultConfig, Src = Self::Extra>
+                + Clone
+                + core::fmt::Debug
+                + PartialEq;
+        }
+
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Clone)]
+        #[wincode(internal)]
+        struct Both<T: HasAssoc> {
+            direct: T,
+            assoc: T::Extra,
+        }
+
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Clone)]
+        #[wincode(internal)]
+        struct MyData {
+            value: u32,
+        }
+
+        impl HasAssoc for MyData {
+            type Extra = String;
+        }
+
+        let original = Both::<MyData> {
+            direct: MyData { value: 42 },
+            assoc: "hello".into(),
+        };
+        let serialized = serialize(&original).unwrap();
+        let deserialized: Both<MyData> = deserialize(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
 }


### PR DESCRIPTION
Previous behaviour:
```rs
pub trait SomeTrait {
    type SomeAssociatedType;
}

#[derive(SchemaRead, SchemaWrite)]
pub struct SomeStruct<T: SomeTrait> {
    pub data: T::SomeAssociatedType
}
```

Despite `SomeStruct` never actually storing a `T`, but only a `T::SomeAssociatedType`, trait bounds were placed on `T` itself. With these changes, trait bounds are only placed in types that are actually used, such as `T::SomeAssociatedType`. If a `T` were stored, bounds would also be placed for T itself.

The original behaviour is very unergonomic for users working with generics. Also, serde has a behaviour similar to the one that was just implemented.

All existing tests are passing, and added new tests specific to this functionality.

As a side note, serde does things a bit differently. `SomeStruct` would compile even if `T::SomeAssociatedType` did not implement serde's traits, but would then error whenever you tried to actually use serde methods on it. However, like in this new approach, it would only require the traits to be placed on types that are actually used in the struct.