### PR TITLE
fix: bv::BitVec canonical decoding

### DIFF
--- a/wincode/src/schema/external/bv.rs
+++ b/wincode/src/schema/external/bv.rs
@@ -2,13 +2,20 @@ use {
     crate::{
         ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
         config::Config,
-        error::invalid_tag_encoding,
+        error::{invalid_tag_encoding, invalid_value},
         io::{Reader, Writer},
         len::SeqLen,
     },
     bv::{BitVec, Bits, BlockType},
     core::mem::MaybeUninit,
 };
+
+#[inline]
+fn expected_block_count<Block: BlockType>(bits_len: u64) -> ReadResult<usize> {
+    let block_bits = Block::nbits() as u64;
+    let block_count = bits_len.div_ceil(block_bits);
+    usize::try_from(block_count).map_err(|_| invalid_value("BitVec block count overflow"))
+}
 
 unsafe impl<C: Config, Block: BlockType + SchemaWrite<C, Src = Block>> SchemaWrite<C>
     for BitVec<Block>
@@ -26,7 +33,7 @@ unsafe impl<C: Config, Block: BlockType + SchemaWrite<C, Src = Block>> SchemaWri
             len_size + if let TypeMeta::Static { size, zero_copy: _ } = Block::TYPE_META {
                 n_blocks * size
             } else {
-                (0..n_blocks).map(|i| Block::size_of(&src.get_raw_block(i))).try_fold(0, |acc, r| r.map(|n| acc + n))?
+                (0..n_blocks).map(|i| Block::size_of(&src.get_block(i))).try_fold(0, |acc, r| r.map(|n| acc + n))?
             }
         };
         let bit_len_size = <u64 as SchemaWrite<C>>::size_of(&src.len())?;
@@ -47,12 +54,12 @@ unsafe impl<C: Config, Block: BlockType + SchemaWrite<C, Src = Block>> SchemaWri
                 #[allow(clippy::arithmetic_side_effects)]
                 let mut writer = unsafe { writer.as_trusted_for(size * n_blocks)? };
                 for i in 0..n_blocks {
-                    Block::write(writer.by_ref(), &src.get_raw_block(i))?;
+                    Block::write(writer.by_ref(), &src.get_block(i))?;
                 }
                 writer.finish()?;
             } else {
                 for i in 0..n_blocks {
-                    Block::write(writer.by_ref(), &src.get_raw_block(i))?;
+                    Block::write(writer.by_ref(), &src.get_block(i))?;
                 }
             }
         }
@@ -66,15 +73,34 @@ unsafe impl<'de, C: Config, Block: BlockType + SchemaRead<'de, C, Dst = Block>> 
     type Dst = BitVec<Block>;
 
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let mut bv = match reader.take_byte()? {
-            0 => BitVec::new(),
-            1 => {
-                let blocks = <Box<[Block]> as SchemaRead<C>>::get(reader.by_ref())?;
-                Self::Dst::from(blocks)
-            }
+        let blocks = match reader.take_byte()? {
+            0 => Box::<[Block]>::default(),
+            1 => <Box<[Block]>>::get(reader.by_ref())?,
             tag => return Err(invalid_tag_encoding(tag as usize)),
         };
         let bits_len = <u64 as SchemaRead<'de, C>>::get(reader)?;
+
+        let expected_blocks = expected_block_count::<Block>(bits_len)?;
+        if blocks.len() != expected_blocks {
+            return Err(invalid_value(
+                "BitVec block count does not match bit length",
+            ));
+        }
+
+        let used_bits_in_final_block = Block::mod_nbits(bits_len);
+        if used_bits_in_final_block != 0 {
+            let padding_mask = !Block::low_mask(used_bits_in_final_block);
+            let Some(final_block) = blocks.last() else {
+                return Err(invalid_value("BitVec missing final block"));
+            };
+            if *final_block & padding_mask != Block::zero() {
+                return Err(invalid_value(
+                    "BitVec final block has non-zero padding bits",
+                ));
+            }
+        }
+
+        let mut bv = Self::Dst::from(blocks);
         bv.truncate(bits_len);
         dst.write(bv);
         Ok(())
@@ -129,6 +155,51 @@ mod tests {
         );
         let deserialized_from_bits: BitVec = deserialize(&serialized_from_bits).unwrap();
         assert_eq!(bv_from_bits, deserialized_from_bits);
+    }
+
+    #[test]
+    fn test_bitvec_read_malleability() {
+        let bv: BitVec<u8> = BitVec::from_bits(vec![true, false, true]);
+        assert_eq!(bv.len(), 3);
+
+        let canonical = serialize(&bv).unwrap();
+        let block_pos = canonical.len() - 1 - core::mem::size_of::<u64>();
+
+        let mut malleable = canonical.clone();
+        malleable[block_pos] |= 0b1111_1000;
+
+        assert_ne!(canonical, malleable);
+
+        let from_canonical: BitVec<u8> = deserialize(&canonical).unwrap();
+        assert_eq!(from_canonical, bv);
+        assert!(deserialize::<BitVec<u8>>(&malleable).is_err());
+    }
+
+    #[test]
+    fn test_bitvec_read_block_count_amplification() {
+        const N_BLOCKS: usize = 4096;
+
+        let big: BitVec<u8> = BitVec::from_bits(vec![true; N_BLOCKS * 8]);
+        assert_eq!(big.block_len(), N_BLOCKS);
+
+        let mut bytes = serialize(&big).unwrap();
+        let len_pos = bytes.len() - core::mem::size_of::<u64>();
+        bytes[len_pos..].copy_from_slice(&1u64.to_le_bytes());
+
+        assert!(deserialize::<BitVec<u8>>(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_bitvec_write_masks_padding_bits() {
+        let mut bv: BitVec<u8> = BitVec::from_bits(vec![true; 8]);
+        bv.truncate(3);
+
+        let bytes = serialize(&bv).unwrap();
+        let block_pos = bytes.len() - 1 - core::mem::size_of::<u64>();
+
+        assert_eq!(bytes[block_pos], 0b0000_0111);
+        let deserialized: BitVec<u8> = deserialize(&bytes).unwrap();
+        assert_eq!(deserialized, bv);
     }
 
     proptest! {


### PR DESCRIPTION
- `block_count` must be exactly the number of blocks needed to hold `bit_len`
- The padding region of the final block (`bit_len % Block::nbits() .. Block::nbits()`) must be all zeros.