### PR TITLE
feat(schema): add Discard and DiscardVec adapters for ignored fields

### DIFF
--- a/wincode/src/schema/adapter.rs
+++ b/wincode/src/schema/adapter.rs
@@ -1,6 +1,8 @@
 //! Schema adapters that serialize a type by converting it to and from the value
 //! of an intermediate "wire" schema.
 
+#[cfg(feature = "alloc")]
+use crate::len::SeqLen;
 use {
     crate::{
         TypeMeta,
@@ -222,12 +224,236 @@ where
     }
 }
 
-#[cfg(all(test, feature = "derive"))]
+/// Reads a value with the `Inner` schema purely to advance the reader, then throws
+/// it away and yields [`Default::default()`] instead.
+///
+/// `Inner` is a *schema*, its bytes are consumed exactly as `Inner` would consume them
+/// — including any validation `Inner` performs — so the surrounding stream stays in sync,
+/// but the decoded value is dropped and the field is filled with the [`Default`] of `Inner`'s
+/// [`SchemaRead::Dst`].
+///
+/// It is meant for fields you don't want to persist, such as a deprecated field
+/// kept only for wire compatibility. On read the encoded value is stepped over and
+/// reset to its [`Default`]; on write the value held in the instance is likewise
+/// ignored and `Inner`'s [`Default`] is serialized in its place. The two directions
+/// agree, so `Discard` works on types deriving both
+/// [`SchemaWrite`](wincode_derive::SchemaWrite) and [`SchemaRead`] — with the
+/// caveat that the original value is *not* preserved across a round-trip: a
+/// discarded field always reads back, and re-serializes, as the default.
+///
+/// For a length-prefixed sequence, prefer [`DiscardSeq`], which steps over every
+/// element without allocating a backing buffer.
+///
+/// ```
+/// # #[cfg(feature = "derive")] {
+/// # use wincode::adapter::Discard;
+/// # use wincode_derive::{SchemaWrite, SchemaRead};
+/// #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+/// struct Full {
+///     ignored: u32,
+///     kept: u16,
+/// }
+///
+/// #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+/// struct Partial {
+///     #[wincode(with = "Discard<u32>")]
+///     ignored: u32,
+///     kept: u16,
+/// }
+///
+/// // On read, `ignored` is stepped over and reset to its default.
+/// let bytes = wincode::serialize(&Full { ignored: 7, kept: 9 }).unwrap();
+/// assert_eq!(
+///     wincode::deserialize::<Partial>(&bytes).unwrap(),
+///     Partial { ignored: 0, kept: 9 },
+/// );
+///
+/// // On write, the held value of `ignored` is discarded and its default is
+/// // serialized, so the output matches a `Full` whose `ignored` is `0`.
+/// let out = wincode::serialize(&Partial { ignored: 7, kept: 9 }).unwrap();
+/// assert_eq!(out, wincode::serialize(&Full { ignored: 0, kept: 9 }).unwrap());
+/// # }
+/// ```
+pub struct Discard<Inner>(PhantomData<Inner>);
+
+unsafe impl<'de, C, Inner> SchemaRead<'de, C> for Discard<Inner>
+where
+    C: ConfigCore,
+    Inner: SchemaRead<'de, C>,
+    Inner::Dst: Default,
+{
+    type Dst = Inner::Dst;
+
+    // Not zero-copy: a fresh `Default` is yielded, not a view of the wire bytes.
+    const TYPE_META: TypeMeta = Inner::TYPE_META.keep_zero_copy(false);
+
+    #[inline]
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        // No byte-skip fast path (unlike `DiscardSeq`): a single value has no
+        // per-element bounds checks to hoist, and dropping the decoded value lets
+        // the optimizer elide the copy out of the reader.
+        Inner::get(reader)?;
+        dst.write(Default::default());
+        Ok(())
+    }
+}
+
+unsafe impl<C, Inner> SchemaWrite<C> for Discard<Inner>
+where
+    C: ConfigCore,
+    Inner: SchemaWrite<C>,
+    Inner::Src: Default,
+{
+    type Src = Inner::Src;
+
+    // Not zero-copy: the `Default` is written, not the instance's own bytes.
+    const TYPE_META: TypeMeta = Inner::TYPE_META.keep_zero_copy(false);
+
+    #[inline]
+    fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+        if let TypeMeta::Static { size, .. } = Inner::TYPE_META {
+            return Ok(size);
+        }
+        Inner::size_of(&Default::default())
+    }
+
+    #[inline]
+    fn write(writer: impl Writer, _src: &Self::Src) -> WriteResult<()> {
+        // Ignore the provided value and match what `read` reconstructs.
+        Inner::write(writer, &Default::default())
+    }
+}
+
+/// Discards a length-prefixed sequence: reads the length (encoded per `Len`) and
+/// steps over every element with the element schema `T`, advancing the reader
+/// exactly as decoding the sequence would, yet never allocates a backing buffer and
+/// always yields an empty [`Vec`].
+///
+/// Every wincode sequence — `Vec`, `String`, slices, sets, and maps — shares the
+/// same *length prefix + elements* wire layout, so this discards **any** of them;
+/// `T` only names one element's wire form:
+///
+/// - a `Vec<u32>`: `DiscardSeq<u32, Len>`;
+/// - a `String`: `DiscardSeq<u8, Len>` (identical bytes to a `Vec<u8>`);
+/// - a map such as `HashMap<K, V>` / `BTreeMap<K, V>`: `DiscardSeq<(K, V), Len>`,
+///   since each entry is encoded as a `(K, V)` pair;
+/// - nested sequences, with no allocation at any level:
+///   `DiscardSeq<DiscardSeq<u8, L2>, L1>` for a `Vec<Vec<u8>>`.
+///
+/// The produced value is always an empty `Vec<T::Dst>`, and that type is
+/// incidental. Deprecating a field is then just repointing it at `DiscardSeq` and
+/// changing its type to the matching `Vec<…>`: the field is dead, so its concrete
+/// collection type no longer matters — only that the bytes are consumed and the
+/// stream stays aligned.
+///
+/// The length prefix is still validated against the configured preallocation
+/// limit, so a hostile length errors out identically to a real read.
+///
+/// Like [`Discard`], the sequence held in the instance is ignored on write and an
+/// empty sequence is emitted, matching what `read` reconstructs. Use the
+/// configuration's default length encoding, e.g.
+/// [`BincodeLen`](crate::len::BincodeLen), to match how the field was originally
+/// encoded.
+///
+/// ```
+/// # #[cfg(all(feature = "alloc", feature = "derive"))] {
+/// # use wincode::{adapter::DiscardSeq, len::BincodeLen};
+/// # use wincode_derive::{SchemaWrite, SchemaRead};
+/// #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+/// struct Full {
+///     data: Vec<u32>,
+///     tag: u8,
+/// }
+///
+/// #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+/// struct Partial {
+///     #[wincode(with = "DiscardSeq<u32, BincodeLen>")]
+///     data: Vec<u32>,
+///     tag: u8,
+/// }
+///
+/// // On read, `data` is stepped over and reset to an empty `Vec`.
+/// let bytes = wincode::serialize(&Full { data: vec![1, 2, 3], tag: 42 }).unwrap();
+/// assert_eq!(
+///     wincode::deserialize::<Partial>(&bytes).unwrap(),
+///     Partial { data: Vec::new(), tag: 42 },
+/// );
+///
+/// // On write, `data` is discarded and an empty sequence is serialized, so the
+/// // output matches a `Full` with empty `data`.
+/// let out = wincode::serialize(&Partial { data: vec![1, 2, 3], tag: 42 }).unwrap();
+/// assert_eq!(out, wincode::serialize(&Full { data: vec![], tag: 42 }).unwrap());
+/// # }
+/// ```
+#[cfg(feature = "alloc")]
+pub struct DiscardSeq<T, Len>(PhantomData<T>, PhantomData<Len>);
+
+#[cfg(feature = "alloc")]
+unsafe impl<'de, C, T, Len> SchemaRead<'de, C> for DiscardSeq<T, Len>
+where
+    C: ConfigCore,
+    Len: SeqLen<C>,
+    T: SchemaRead<'de, C>,
+{
+    type Dst = alloc::vec::Vec<T::Dst>;
+
+    #[inline]
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let len = Len::read_prealloc_check::<T::Dst>(reader.by_ref())?;
+        if let TypeMeta::Static { size, .. } = T::TYPE_META {
+            // Reserve the whole `len * size`-byte body up front so the per-element
+            // decodes below elide their own bounds checks. `get` still validates
+            // each element, so non-zero-copy types are handled correctly too.
+            //
+            // SAFETY: exactly `len` decodes of `size` bytes run through the trusted window
+            let mut trusted = unsafe { reader.as_trusted_for_seq(len, size)? };
+            for _ in 0..len {
+                T::get(trusted.by_ref())?;
+            }
+        } else {
+            for _ in 0..len {
+                T::get(reader.by_ref())?;
+            }
+        }
+        dst.write(alloc::vec::Vec::new());
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+unsafe impl<C, T, Len> SchemaWrite<C> for DiscardSeq<T, Len>
+where
+    C: ConfigCore,
+    Len: SeqLen<C>,
+    T: SchemaWrite<C>,
+    T::Src: Sized,
+{
+    type Src = alloc::vec::Vec<T::Src>;
+
+    #[inline]
+    fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+        // An empty sequence: just the length prefix for 0.
+        Len::write_bytes_needed(0)
+    }
+
+    #[inline]
+    fn write(writer: impl Writer, _src: &Self::Src) -> WriteResult<()> {
+        // Ignore the provided sequence; emit an empty one, matching `read`.
+        Len::write(writer, 0)
+    }
+}
+
+#[cfg(all(test, feature = "derive", feature = "alloc"))]
 mod tests {
-    use crate::{
-        SchemaRead, SchemaWrite,
-        adapter::{DefaultOnEmptyRead, FromInto},
-        deserialize, serialize,
+    use {
+        crate::{
+            SchemaRead, SchemaWrite,
+            adapter::{DefaultOnEmptyRead, Discard, DiscardSeq, FromInto},
+            deserialize,
+            len::BincodeLen,
+            serialize,
+        },
+        alloc::{collections::BTreeMap, string::String, vec::Vec},
     };
 
     /// A self-describing wire schema: the wire value is a plain `u32`.
@@ -265,13 +491,9 @@ mod tests {
 
     /// `Wire` is a schema *adapter* whose value type differs from itself:
     /// `containers::Vec<u8, _>` serializes a `Vec<u8>`.
-    #[cfg(feature = "alloc")]
     #[test]
     fn adapter_wire() {
-        use {
-            crate::{containers, len::UseIntLen},
-            alloc::{string::String, vec::Vec},
-        };
+        use crate::{containers, len::UseIntLen};
 
         #[derive(Debug, PartialEq, Clone)]
         struct Name(String);
@@ -349,6 +571,113 @@ mod tests {
                 id: 0,
                 added_later: 0,
             }
+        );
+    }
+
+    #[test]
+    fn discard_seq_nested() {
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+        #[wincode(internal)]
+        struct Full {
+            pairs: Vec<(u32, u16)>,
+            singles: Vec<u32>,
+            nested: Vec<Vec<u8>>,
+            map: BTreeMap<u32, u64>,
+            tag: u8,
+        }
+
+        #[derive(SchemaRead, Debug, PartialEq)]
+        #[wincode(internal)]
+        struct Partial {
+            // Composite static element via the trusted-window path.
+            #[wincode(with = "DiscardSeq<(u32, u16), BincodeLen>")]
+            pairs: Vec<(u32, u16)>,
+            // `Discard` composed as the element schema.
+            #[wincode(with = "DiscardSeq<Discard<u32>, BincodeLen>")]
+            singles: Vec<u32>,
+            // Nested `DiscardSeq`: discards `Vec<Vec<u8>>` with no allocation at
+            // any level while still yielding `Vec<Vec<u8>>`.
+            #[wincode(with = "DiscardSeq<DiscardSeq<u8, BincodeLen>, BincodeLen>")]
+            nested: Vec<Vec<u8>>,
+            // A map is a sequence of `(K, V)` entries; the field type is now an
+            // incidental `Vec`.
+            #[wincode(with = "DiscardSeq<(u32, u64), BincodeLen>")]
+            map: Vec<(u32, u64)>,
+            tag: u8,
+        }
+
+        let bytes = serialize(&Full {
+            pairs: vec![(1, 2), (3, 4)],
+            singles: vec![10, 20, 30],
+            nested: vec![vec![1, 2], vec![], vec![9]],
+            map: BTreeMap::from([(1, 10), (2, 20), (3, 30)]),
+            tag: 7,
+        })
+        .unwrap();
+        assert_eq!(
+            deserialize::<Partial>(&bytes).unwrap(),
+            Partial {
+                pairs: Vec::new(),
+                singles: Vec::new(),
+                nested: Vec::new(),
+                map: Vec::new(),
+                tag: 7,
+            },
+        );
+    }
+
+    #[test]
+    fn discard_seq_validates_non_zero_copy_elements() {
+        #[derive(SchemaRead, Debug, PartialEq)]
+        #[wincode(internal)]
+        struct Partial {
+            #[wincode(with = "DiscardSeq<bool, BincodeLen>")]
+            flags: Vec<bool>,
+        }
+
+        let ok = serialize(&vec![true, false]).unwrap();
+        assert_eq!(
+            deserialize::<Partial>(&ok).unwrap(),
+            Partial { flags: Vec::new() },
+        );
+
+        // A non-canonical bool byte must still be rejected, not skipped.
+        let mut bad = ok.clone();
+        *bad.last_mut().unwrap() = 2;
+        assert!(deserialize::<Partial>(&bad).is_err());
+    }
+
+    #[test]
+    fn discard_string_as_bytes() {
+        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq)]
+        #[wincode(internal)]
+        struct Full {
+            text: String,
+            tag: u8,
+        }
+
+        // A `String` shares its wire format with `Vec<u8>`, so it is discarded as
+        // raw bytes via `DiscardSeq<u8>`: no allocation, and the following field
+        // stays aligned.
+        #[derive(SchemaRead, Debug, PartialEq)]
+        #[wincode(internal)]
+        struct Partial {
+            #[wincode(with = "DiscardSeq<u8, BincodeLen>")]
+            text: Vec<u8>,
+            tag: u8,
+        }
+
+        let bytes = serialize(&Full {
+            text: "hello".into(),
+            tag: 7,
+        })
+        .unwrap();
+        assert_eq!(
+            deserialize::<Partial>(&bytes).unwrap(),
+            Partial {
+                text: Vec::new(),
+                tag: 7,
+            },
         );
     }
 }


### PR DESCRIPTION
#### Problem
As wire format schemas evolve, there are cases where given value stops being populated / used and should be ignored, while preserving backwards compatibility, e.g.
https://github.com/anza-xyz/agave/blob/e7b03044cf8bc1225eb38b3061348a0117459be6/runtime/src/epoch_stakes.rs#L465

#### Summary of Changes
Provide adapters for fields that should no longer be carried, such as a deprecated field kept only for wire compatibility. On read the encoded value is consumed and validated but reset to its Default; on write the held value is ignored and the Default is serialized. This keeps the stream in sync and both directions consistent while treating the field as absent.
    
`DiscardSeq<T, Len>` does the same for any length-prefixed sequence without allocating a backing buffer, where T is the element schema. Since `Vec`, `String`, sets and maps all share the length-prefix + elements wire layout, one adapter covers them all (a `String` via `DiscardSeq<u8, _>`, a map via `DiscardSeq<(K, V), _>`), and it nests: `DiscardSeq<DiscardSeq<u8, L>, L>` discards a `Vec<Vec<u8>>` with no allocation at any level. The yielded `Vec` type is incidental, so deprecating a field is just repointing it at `DiscardSeq`.
