### PR TITLE
fix(schema): fix asymmetric application of write preallocation check

### DIFF
--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -429,7 +429,8 @@ where
         } = T::TYPE_META
         {
             #[allow(clippy::arithmetic_side_effects)]
-            let needed = Len::write_bytes_needed_prealloc_check::<T>(src.len())? + src.len() * size;
+            let needed =
+                Len::write_bytes_needed_prealloc_check::<T::Src>(src.len())? + src.len() * size;
             // SAFETY: `needed` is the size of the encoded length plus the size of the items.
             // `Len::write` and `len` writes of `T::Src` will write `needed` bytes,
             // fully initializing the trusted window.
@@ -450,7 +451,7 @@ where
             return Ok(());
         }
 
-        write_elem_iter::<T, Len, C>(writer, src.iter())
+        write_elem_iter_prealloc_check::<T, Len, C>(writer, src.iter())
     }
 }
 
@@ -829,6 +830,7 @@ where
     C: ConfigCore,
     Len: SeqLen<C>,
     T: SchemaWrite<C>,
+    T::Src: Sized,
 {
     write_elem_iter_prealloc_check::<T, Len, C>(writer, src.into_iter())
 }

--- a/wincode/src/schema/external/bv.rs
+++ b/wincode/src/schema/external/bv.rs
@@ -46,6 +46,7 @@ unsafe impl<C: Config, Block: BlockType + SchemaWrite<C, Src = Block>> SchemaWri
         if n_blocks == 0 {
             writer.write(&[0])?; // None
         } else {
+            C::LengthEncoding::prealloc_check::<Block>(n_blocks)?;
             writer.write(&[1])?; // Some
             C::LengthEncoding::write(writer.by_ref(), n_blocks)?;
             if let TypeMeta::Static { size, zero_copy: _ } = Block::TYPE_META {

--- a/wincode/src/schema/external/bytes.rs
+++ b/wincode/src/schema/external/bytes.rs
@@ -3,6 +3,7 @@ use {
         ReadResult, SchemaRead, SchemaWrite, WriteResult,
         config::Config,
         io::{Reader, Writer},
+        len::SeqLen,
     },
     alloc::boxed::Box,
     bytes::{Bytes, BytesMut},
@@ -28,6 +29,7 @@ unsafe impl<C: Config> SchemaWrite<C> for Bytes {
     }
 
     fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        C::LengthEncoding::prealloc_check::<u8>(src.len())?;
         <[u8] as SchemaWrite<C>>::write(writer, src.as_ref())
     }
 }
@@ -53,6 +55,7 @@ unsafe impl<C: Config> SchemaWrite<C> for BytesMut {
     }
 
     fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        C::LengthEncoding::prealloc_check::<u8>(src.len())?;
         <[u8] as SchemaWrite<C>>::write(writer, src.as_ref())
     }
 }

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -1145,7 +1145,7 @@ macro_rules! impl_seq_kv {
                 if let ($crate::TypeMeta::Static { size: key_size, .. }, $crate::TypeMeta::Static { size: value_size, .. }) = ($key::TYPE_META, $value::TYPE_META) {
                     let len = src.len();
                     #[allow(clippy::arithmetic_side_effects)]
-                    let needed = C::LengthEncoding::write_bytes_needed_prealloc_check::<($key, $value)>(len)? + (key_size + value_size) * len;
+                    let needed = C::LengthEncoding::write_bytes_needed_prealloc_check::<($key::Src, $value::Src)>(len)? + (key_size + value_size) * len;
                     // SAFETY: `$key::TYPE_META` and `$value::TYPE_META` specify static sizes, so `len` writes of `($key::Src, $value::Src)`
                     // and `<BincodeLen>::write` will write `needed` bytes, fully initializing the trusted window.
                     let mut writer = unsafe { writer.as_trusted_for(needed) }?;
@@ -1157,7 +1157,9 @@ macro_rules! impl_seq_kv {
                     writer.finish()?;
                     return Ok(());
                 }
-                C::LengthEncoding::write(writer.by_ref(), src.len())?;
+                let len = src.len();
+                C::LengthEncoding::prealloc_check::<($key::Src, $value::Src)>(len)?;
+                C::LengthEncoding::write(writer.by_ref(), len)?;
                 for (k, v) in src.iter() {
                     $key::write(writer.by_ref(), k)?;
                     $value::write(writer.by_ref(), v)?;

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -514,8 +514,9 @@ where
     C: ConfigCore,
     Len: SeqLen<C>,
     T: SchemaWrite<C>,
+    T::Src: Sized,
 {
-    Len::prealloc_check::<T>(src.len())?;
+    Len::prealloc_check::<T::Src>(src.len())?;
     write_elem_iter::<T, Len, C>(writer, src)
 }
 
@@ -561,7 +562,7 @@ where
     T: SchemaWrite<C>,
     T::Src: Sized,
 {
-    Len::prealloc_check::<T>(src.len())?;
+    Len::prealloc_check::<T::Src>(src.len())?;
     write_elem_slice::<T, Len, C>(writer, src)
 }
 


### PR DESCRIPTION
There are numerous locations where write-side preallocation checks are not symmetric with read-side.

Perhaps most prominently (given their extensive usage), `write_elem_slice_prealloc_check` and `write_elem_iter_prealloc_check` use `T` rather than `T::Src` as the sizing target. This is problematic specifically on `SchemaWrite` types `T` whose `Src` is _not_ `T` (e.g., mapped types).

Other locations were either just missing entirely or similarly to the above checking `T` instead of `T::Src`.