### PR TITLE
fix(derive): compute zero-copy layout against `from` target

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -203,6 +203,7 @@ pub(crate) trait FieldsExt {
         trait_impl: TraitImpl,
         repr: &StructRepr,
         crate_name: &Path,
+        dst: &Type,
     ) -> TokenStream;
     /// Get an iterator over the fields and their identifiers for the struct members.
     ///
@@ -232,6 +233,7 @@ impl FieldsExt for Fields<Field> {
         trait_impl: TraitImpl,
         repr: &StructRepr,
         crate_name: &Path,
+        dst: &Type,
     ) -> TokenStream {
         let tuple_expansion = match trait_impl {
             TraitImpl::SchemaRead => {
@@ -263,7 +265,11 @@ impl FieldsExt for Fields<Field> {
                 // the fields must be equal to the in-memory size of the type. This is because zero-copy types
                 // may be read/written directly using their in-memory representation; padding disqualifies a type
                 // from this kind of optimization.
-                let no_padding = serialized_size == core::mem::size_of::<Self>();
+                //
+                // The zero-copy readers reinterpret the input bytes as `Dst`/`Src` (the
+                // `#[wincode(from = "T")]` target when a mapping is used, otherwise `Self`),
+                // so the size must be compared against that target rather than `Self`.
+                let no_padding = serialized_size == core::mem::size_of::<#dst>();
                 #crate_name::TypeMeta::Static { size: serialized_size, zero_copy: no_padding && #is_zero_copy_eligible && zero_copy }
             } else {
                 #crate_name::TypeMeta::Dynamic

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -81,7 +81,8 @@ fn impl_struct(
         })
         .collect::<Vec<_>>();
 
-    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaRead, repr, crate_name);
+    let src_dst = get_src_dst(args);
+    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaRead, repr, crate_name, &src_dst);
 
     let drop_guard = (0..fields.len()).map(|i| {
         // Generate code to drop already initialized fields in reverse order.
@@ -463,6 +464,14 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
                 && args.generics.lifetimes().next().is_none() =>
         {
             let field_tys = fields.iter().map(|field| &field.ty);
+            // The zero-copy readers reinterpret the input bytes as `Dst` (the
+            // `#[wincode(from = "T")]` target when a mapping is used, otherwise
+            // `Self`), so the no-padding assertion must be tied to `Dst`.
+            let zero_copy_target = args
+                .from
+                .as_ref()
+                .map(|from| quote!(#from))
+                .unwrap_or_else(|| quote!(#ident));
             let mut bounds = Punctuated::new();
             bounds.push(parse_quote!(__WincodeIsTrue));
             let no_pad_predicate = WherePredicate::Type(PredicateType {
@@ -472,7 +481,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
                 bounded_ty: parse_quote!(
                     __WincodeAssert<
                         {
-                            #(core::mem::size_of::<#field_tys>())+* == core::mem::size_of::<#ident>()
+                            #(core::mem::size_of::<#field_tys>())+* == core::mem::size_of::<#zero_copy_target>()
                         },
                     >
                 ),

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -20,6 +20,7 @@ use {
 };
 
 fn impl_struct(
+    args: &SchemaArgs,
     fields: &Fields<Field>,
     repr: &StructRepr,
     crate_name: &Path,
@@ -53,7 +54,8 @@ fn impl_struct(
         })
         .collect::<Vec<_>>();
 
-    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaWrite, repr, crate_name);
+    let src_dst = get_src_dst(args);
+    let type_meta_impl = fields.type_meta_impl(TraitImpl::SchemaWrite, repr, crate_name, &src_dst);
 
     (
         quote! {
@@ -310,7 +312,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             }
             // Only structs are eligible being marked zero-copy, so only the struct
             // impl needs the repr.
-            impl_struct(fields, &repr, &crate_name)
+            impl_struct(&args, fields, &repr, &crate_name)
         }
         Data::Enum(v) => {
             let enum_ident = match &args.from {

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -78,3 +78,35 @@ fn derive_tag_uniqueness_repr_normalization() {}
 /// # }
 /// ```
 fn derive_tag_uniqueness_implicit_collision() {}
+
+/// A `#[wincode(from = "T")]` schema whose fields do not cover the full layout of
+/// the target `T` must not be classified zero-copy: the zero-copy slice readers
+/// borrow `len * schema_size` bytes but form `&[T]` spanning `len * size_of::<T>()`,
+/// which would read/write past the input buffer. Such a schema must fail to satisfy
+/// `ZeroCopy`, so `&[Schema]` does not implement `SchemaRead`.
+///
+/// ```compile_fail
+/// # #[cfg(feature = "derive")] {
+/// use wincode::{SchemaRead, config::DefaultConfig};
+///
+/// #[repr(C)]
+/// pub struct Foreign {
+///     pub a: u64,
+///     pub b: u64,
+///     pub c: u64, // <-- NOT represented in the schema below
+/// }
+///
+/// #[derive(wincode::SchemaWrite, wincode::SchemaRead)]
+/// #[wincode(from = "Foreign")]
+/// #[repr(C)]
+/// struct Schema {
+///     a: u64,
+///     b: u64,
+/// }
+///
+/// let buf = [0u8; 8 + 2 * 16];
+/// let _: &[Foreign] =
+///     <&[Schema] as SchemaRead<'_, DefaultConfig>>::get(&buf[..]).unwrap();
+/// # }
+/// ```
+fn from_mapping_layout_mismatch_is_not_zero_copy() {}

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1614,6 +1614,35 @@ mod tests {
     }
 
     #[test]
+    fn test_from_mapping_type_meta_zero_copy_flag() {
+        #[repr(C)]
+        struct Foreign {
+            a: u64,
+            b: u64,
+            c: u64,
+        }
+
+        #[derive(SchemaWrite, SchemaRead)]
+        #[wincode(internal, from = "Foreign")]
+        #[repr(C)]
+        struct Mismatched {
+            a: u64,
+            b: u64,
+        }
+
+        // `Mismatched` does not cover all of `Foreign`, so the flag must be cleared:
+        // it is computed against the reinterpret target `Foreign`, not the schema struct.
+        let expected = TypeMeta::Static {
+            size: 16,
+            zero_copy: false,
+        };
+        let read_meta = <Mismatched as SchemaRead<'_, DefaultConfig>>::TYPE_META;
+        let write_meta = <Mismatched as SchemaWrite<DefaultConfig>>::TYPE_META;
+        assert_eq!(read_meta, expected);
+        assert_eq!(read_meta, write_meta);
+    }
+
+    #[test]
     fn test_uninit_builder_builder_fully_initialized() {
         #[derive(SchemaWrite, UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]


### PR DESCRIPTION
#### Problem
`#[wincode(from = "T")]` classifies zero-copy using the schema struct layout instead of the target `T`. A schema that does not cover all of `T` is marked zero-copy with a too-small size, so the slice readers borrow fewer bytes than the `&[T]` they produced, reading/writing past the input buffer.

#### Summary of Changes
* use target type when comparing its size to size of fields
* pass-through info to calculate correct zero-copy flag when generating TYPE_META fields