### PR TITLE
chore(derive)!: remove derive `from` attribute

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -470,43 +470,6 @@ impl VariantsExt for &[Variant] {
 
 pub(crate) type ImplBody = Data<Variant, Field>;
 
-/// Generate code to suppress unused field lints.
-///
-/// If `from` is specified, the user is creating a mapping type, in which case those struct/enum
-/// fields will almost certainly be unused, as they exist purely to describe the mapping. This will
-/// trigger unused field lints.
-///
-/// Create a private, never-called item that references the fields to avoid unused field lints.
-/// Users can disable this by setting `no_suppress_unused`.
-pub(crate) fn suppress_unused_fields(args: &SchemaArgs) -> TokenStream {
-    if args.from.is_none() || args.no_suppress_unused {
-        return quote! {};
-    }
-
-    match &args.data {
-        Data::Struct(fields) if !fields.is_empty() => {
-            let idents = fields.struct_members_iter().map(|(_, ident)| ident);
-            let ident = &args.ident;
-            let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
-            quote! {
-                const _: () = {
-                    #[allow(dead_code, unused_variables)]
-                    fn __wincode_use_fields #impl_generics (value: &#ident #ty_generics) #where_clause {
-                        let _ = ( #( &value.#idents ),* );
-                    }
-                };
-            }
-        }
-        // We can't suppress the lint on on enum variants, as that would require being able to
-        // construct an arbitrary enum variant, which we can't do. Users will have to manually
-        // add a `#[allow(unused)]` / `#[allow(dead_code)]` attribute to the enum variant if they want to
-        // suppress the lint, or make it public.
-        _ => {
-            quote! {}
-        }
-    }
-}
-
 /// Get the path to `wincode` based on the `internal` or `crate_path` option.
 pub(crate) fn get_crate_name(args: &SchemaArgs) -> Path {
     if let Some(crate_path) = &args.crate_path {
@@ -515,33 +478,6 @@ pub(crate) fn get_crate_name(args: &SchemaArgs) -> Path {
         parse_quote!(crate)
     } else {
         parse_quote!(::wincode)
-    }
-}
-
-/// Get the target `Src` or `Dst` type for a `SchemaRead` or `SchemaWrite` implementation.
-///
-/// If `from` is specified, the user is implementing `SchemaRead` or `SchemaWrite` on a foreign type,
-/// so we return the `from` type.
-/// Otherwise, we return the ident + ty_generics (target is `Self`).
-pub(crate) fn get_src_dst(args: &SchemaArgs) -> Cow<'_, Type> {
-    if let Some(from) = args.from.as_ref() {
-        Cow::Borrowed(from)
-    } else {
-        Cow::Owned(parse_quote!(Self))
-    }
-}
-
-/// Get the fully qualified target `Src` or `Dst` type for a `SchemaRead` or `SchemaWrite` implementation.
-///
-/// Like [`Self::get_src_dst`], but rather than producing `Self` when implementing a local type,
-/// we return the fully qualified type.
-pub(crate) fn get_src_dst_fully_qualified(args: &SchemaArgs) -> Cow<'_, Type> {
-    if let Some(from) = args.from.as_ref() {
-        Cow::Borrowed(from)
-    } else {
-        let ident = &args.ident;
-        let (_, ty_generics, _) = args.generics.split_for_impl();
-        Cow::Owned(parse_quote!(#ident #ty_generics))
     }
 }
 
@@ -559,16 +495,6 @@ pub(crate) struct SchemaArgs {
     /// Otherwise, it will use the `wincode` path.
     #[darling(default)]
     pub(crate) internal: bool,
-    /// Specifies whether the type's implementations should map to another type.
-    ///
-    /// Useful for implementing `SchemaRead` and `SchemaWrite` on foreign types.
-    #[darling(default)]
-    pub(crate) from: Option<Type>,
-    /// Specifies whether to suppress unused field lints on structs.
-    ///
-    /// Only applicable if `from` is specified.
-    #[darling(default)]
-    pub(crate) no_suppress_unused: bool,
     /// Specifies whether to generate placement initialization struct helpers on `SchemaRead` implementations.
     ///
     /// DEPRECATED; use `#[derive(UninitBuilder)]` instead.

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -4,7 +4,6 @@ use {
         common::{
             Field, FieldsExt, GenericField, SchemaArgs, StructRepr, TraitImpl, TypeExt, Variant,
             VariantsExt, default_tag_encoding, extract_repr, generic_field_types, get_crate_name,
-            get_src_dst, get_src_dst_fully_qualified, suppress_unused_fields,
         },
         uninit_builder::impl_uninit_builder,
     },
@@ -117,7 +116,7 @@ fn impl_struct(
         _ => panic!("Unsupported number of fields: {}", fields.len()),
     };
 
-    let dst = get_src_dst_fully_qualified(args);
+    let ident = &args.ident;
     let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
     let init_guard = quote! {
         let dst_ptr = dst.as_mut_ptr();
@@ -131,7 +130,7 @@ fn impl_struct(
         quote! {
             struct __WincodeDropGuard #impl_generics #where_clause {
                 init_count: #counter_ty,
-                dst_ptr: *mut #dst,
+                dst_ptr: *mut #ident #ty_generics,
             }
 
             impl #impl_generics ::core::ops::Drop for __WincodeDropGuard #ty_generics #where_clause {
@@ -172,7 +171,6 @@ fn impl_struct(
 }
 
 fn impl_enum(
-    enum_ident: &Type,
     variants: &[Variant],
     tag_encoding_override: Option<&Type>,
     crate_name: &Path,
@@ -231,11 +229,11 @@ fn impl_enum(
 
                 let constructor = if style.is_struct() {
                     quote! {
-                        #enum_ident::#variant_ident{#(#construct_idents),*}
+                        Self::#variant_ident{#(#construct_idents),*}
                     }
                 } else {
                     quote! {
-                        #enum_ident::#variant_ident(#(#construct_idents),*)
+                        Self::#variant_ident(#(#construct_idents),*)
                     }
                 };
 
@@ -259,7 +257,7 @@ fn impl_enum(
 
             Style::Unit => quote! {
                 #discriminant => {
-                    dst.write(#enum_ident::#variant_ident);
+                    dst.write(Self::#variant_ident);
                 }
             },
         }
@@ -412,8 +410,6 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let src_dst = get_src_dst(&args);
-    let field_suppress = suppress_unused_fields(&args);
     let struct_extensions = if args.struct_extensions {
         let tokens = impl_uninit_builder(&args, &crate_name)?;
         let deprecation = quote_spanned! {args.ident.span()=>
@@ -442,13 +438,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             // impl needs the repr.
             impl_struct(&args, fields, &repr, &crate_name)
         }
-        Data::Enum(v) => {
-            let enum_ident = match &args.from {
-                Some(from) => from,
-                None => &parse_quote!(Self),
-            };
-            impl_enum(enum_ident, v, args.tag_encoding.as_ref(), &crate_name)
-        }
+        Data::Enum(v) => impl_enum(v, args.tag_encoding.as_ref(), &crate_name),
     };
 
     // Provide a `ZeroCopy` impl for the type if its `repr` is eligible and all its fields are zero-copy.
@@ -528,7 +518,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             #zero_copy_impl
 
             unsafe impl #impl_generics #crate_name::SchemaRead<'de, __WincodeConfig> for #ident #ty_generics #where_clause {
-                type Dst = #src_dst;
+                type Dst = Self;
 
                 #[allow(clippy::arithmetic_side_effects)]
                 const TYPE_META: #crate_name::TypeMeta = #type_meta_impl;
@@ -542,6 +532,5 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
         };
         #zero_copy_asserts
         #struct_extensions
-        #field_suppress
     })
 }

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -4,7 +4,6 @@ use {
         common::{
             Field, FieldsExt, GenericField, SchemaArgs, StructRepr, TraitImpl, Variant,
             VariantsExt, default_tag_encoding, extract_repr, generic_field_types, get_crate_name,
-            get_src_dst, suppress_unused_fields,
         },
     },
     darling::{
@@ -88,7 +87,6 @@ fn impl_struct(
 }
 
 fn impl_enum(
-    enum_ident: &Type,
     variants: &[Variant],
     tag_encoding_override: Option<&Type>,
     crate_name: &Path,
@@ -162,11 +160,11 @@ fn impl_enum(
                     .collect::<Vec<_>>();
                 let match_case = if style.is_struct() {
                     quote! {
-                        #enum_ident::#variant_ident{#(#pattern_fragments),*}
+                        Self::#variant_ident{#(#pattern_fragments),*}
                     }
                 } else {
                     quote! {
-                        #enum_ident::#variant_ident(#(#pattern_fragments),*)
+                        Self::#variant_ident(#(#pattern_fragments),*)
                     }
                 };
 
@@ -216,12 +214,12 @@ fn impl_enum(
 
             Style::Unit => (
                 quote! {
-                    #enum_ident::#variant_ident => {
+                    Self::#variant_ident => {
                         Ok(#size_of_discriminant)
                     }
                 },
                 quote! {
-                    #enum_ident::#variant_ident => {
+                    Self::#variant_ident => {
                         #write_discriminant;
                         Ok(())
                     }
@@ -299,8 +297,6 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let src_dst = get_src_dst(&args);
-    let field_suppress = suppress_unused_fields(&args);
     let zero_copy_asserts = assert_zero_copy(&args, &repr)?;
 
     let (size_of_impl, write_impl, type_meta_impl) = match &args.data {
@@ -312,19 +308,13 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             // impl needs the repr.
             impl_struct(fields, &repr, &crate_name)
         }
-        Data::Enum(v) => {
-            let enum_ident = match &args.from {
-                Some(from) => from,
-                None => &parse_quote!(Self),
-            };
-            impl_enum(enum_ident, v, args.tag_encoding.as_ref(), &crate_name)
-        }
+        Data::Enum(v) => impl_enum(v, args.tag_encoding.as_ref(), &crate_name),
     };
 
     Ok(quote! {
         const _: () = {
             unsafe impl #impl_generics #crate_name::SchemaWrite<__WincodeConfig> for #ident #ty_generics #where_clause {
-                type Src = #src_dst;
+                type Src = Self;
 
                 #[allow(clippy::arithmetic_side_effects)]
                 const TYPE_META: #crate_name::TypeMeta = #type_meta_impl;
@@ -341,6 +331,5 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             }
         };
         #zero_copy_asserts
-        #field_suppress
     })
 }

--- a/wincode-derive/src/uninit_builder.rs
+++ b/wincode-derive/src/uninit_builder.rs
@@ -1,7 +1,5 @@
 use {
-    crate::common::{
-        SchemaArgs, TypeExt, extract_repr, get_crate_name, get_src_dst_fully_qualified,
-    },
+    crate::common::{SchemaArgs, TypeExt, extract_repr, get_crate_name},
     darling::{Error, FromDeriveInput, Result, ast::Data},
     proc_macro2::{Span, TokenStream},
     quote::{format_ident, quote},
@@ -33,8 +31,10 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         parse_quote!(__WincodeConfig: #crate_name::config::Config),
     ));
 
-    let builder_dst = get_src_dst_fully_qualified(args);
-
+    let builder_dst = {
+        let (_, ty_generics, _) = args.generics.split_for_impl();
+        quote!(#struct_ident #ty_generics)
+    };
     let (builder_impl_generics, builder_ty_generics, builder_where_clause) =
         builder_generics.split_for_impl();
     // Determine how many bits are needed to track the initialization state of the fields.

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -69,98 +69,6 @@
 //! `wincode` makes in-place initialization a first class design goal, and fundamentally
 //! operates on [traits](#traits) that facilitate direct writes of memory.
 //!
-//! # Adapting foreign types
-//!
-//! `wincode` can also be used to implement serialization/deserialization
-//! on foreign types, where serialization/deserialization schemes on those types are unoptimized (and
-//! out of your control as a foreign type). For example, consider the following struct,
-//! defined outside of your crate:
-//! ```
-//! use serde::{Serialize, Deserialize};
-//!
-//! # #[derive(PartialEq, Eq, Debug)]
-//! #[repr(transparent)]
-//! #[derive(Clone, Copy, Serialize, Deserialize)]
-//! struct Address([u8; 32]);
-//!
-//! # #[derive(PartialEq, Eq, Debug)]
-//! #[repr(transparent)]
-//! #[derive(Clone, Copy, Serialize, Deserialize)]
-//! struct Hash([u8; 32]);
-//!
-//! #[derive(Serialize, Deserialize)]
-//! pub struct A {
-//!     pub addresses: Vec<Address>,
-//!     pub hash: Hash,
-//! }
-//! ```
-//!
-//! `serde`'s default, naive, implementation will perform per-element visitation of all bytes
-//! in `Vec<Address>` and `Hash`. Because these fields are "plain old data", ideally we would
-//! avoid per-element visitation entirely and read / write these fields in a single pass.
-//! The situation worsens if this struct needs to be written into a heap allocated data structure,
-//! like a `Vec<A>` or `Box<[A]>`. As discussed in [motivation](#motivation), all
-//! those bytes will be initialized on the stack before being copied into the heap allocation.
-//!
-//! `wincode` can solve this with the following:
-//! ```
-//! # #[cfg(all(feature = "alloc", feature = "derive"))] {
-//! # use wincode::{Serialize as _, Deserialize as _, containers};
-//! # use wincode_derive::{SchemaWrite, SchemaRead};
-//! mod foreign_crate {
-//!     // Defined in some foreign crate...
-//!     use serde::{Serialize, Deserialize};
-//!
-//!     # #[derive(PartialEq, Eq, Debug)]
-//!     #[repr(transparent)]
-//!     #[derive(Clone, Copy, Serialize, Deserialize)]
-//!     pub struct Address(pub [u8; 32]);
-//!
-//!     # #[derive(PartialEq, Eq, Debug)]
-//!     #[repr(transparent)]
-//!     #[derive(Clone, Copy, Serialize, Deserialize)]
-//!     pub struct Hash(pub [u8; 32]);
-//!
-//!     # #[derive(PartialEq, Eq, Debug)]
-//!     #[derive(Serialize, Deserialize)]
-//!     pub struct A {
-//!         pub addresses: Vec<Address>,
-//!         pub hash: Hash,
-//!     }
-//! }
-//!
-//! wincode::pod_wrapper! {
-//!     unsafe struct PodAddress(foreign_crate::Address);
-//!     unsafe struct PodHash(foreign_crate::Hash);
-//! }
-//!
-//! #[derive(SchemaWrite, SchemaRead)]
-//! #[wincode(from = "foreign_crate::A")]
-//! pub struct MyA {
-//!     addresses: Vec<PodAddress>,
-//!     hash: PodHash,
-//! }
-//!
-//! let val = foreign_crate::A {
-//!     addresses: vec![foreign_crate::Address([0; 32]), foreign_crate::Address([1; 32])],
-//!     hash: foreign_crate::Hash([0; 32]),
-//! };
-//! let bincode_serialize = bincode::serialize(&val).unwrap();
-//! let wincode_serialize = MyA::serialize(&val).unwrap();
-//! assert_eq!(bincode_serialize, wincode_serialize);
-//!
-//! let bincode_deserialize: foreign_crate::A = bincode::deserialize(&bincode_serialize).unwrap();
-//! let wincode_deserialize = MyA::deserialize(&bincode_serialize).unwrap();
-//! assert_eq!(val, bincode_deserialize);
-//! assert_eq!(val, wincode_deserialize);
-//! # }
-//! ```
-//!
-//! Now, when deserializing `A`:
-//! - All initialization is done in-place, including heap-allocated memory
-//!   (true of all supported contiguous heap-allocated structures in `wincode`).
-//! - Byte fields are read and written in a single pass.
-//!
 //! # Compatibility
 //!
 //! - Produces the same bytes as `bincode` for the covered shapes when using bincode's
@@ -330,25 +238,10 @@
 //! ## Top level
 //! |Attribute|Type|Default|Description
 //! |---|---|---|---|
-//! |`from`|`Type`|`None`|Indicates that type is a mapping from another type (example in previous section)|
-//! |`no_suppress_unused`|`bool`|`false`|Disable unused field lints suppression. Only usable on structs with `from`.|
 //! |`struct_extensions` (DEPRECATED)|`bool`|`false`|Generates placement initialization helpers on `SchemaRead` struct implementations. DEPRECATED; Use `#[derive(UninitBuilder)]` instead.|
 //! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
 //! |`assert_zero_copy`|`bool`\|`Path`|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. Can specify a custom config path, will use the [`DefaultConfig`](config::DefaultConfig) if `bool` form is used.|
 //! |`crate`|`Path`|`::wincode`|Specifies the path to the `wincode` crate. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module. The path is emitted as written and resolved from the derive expansion site.|
-//!
-//! ### `no_suppress_unused`
-//!
-//! When creating a mapping type with `#[wincode(from = "AnotherType")]`, fields are typically
-//! comprised of [`containers`] (of course not strictly always true). As a result, these structs
-//! purely exist for the compiler to generate optimized implementations, and are never actually
-//! constructed. As a result, unused field lints will be triggered, which can be annoying.
-//! By default, when `from` is used, the derive macro will generate dummy function that references all
-//! the struct fields, which suppresses those lints. This function will ultimately be compiled out of your
-//! build, but you can disable this by setting `no_suppress_unused` to `true`. You can also avoid
-//! these lint errors with visibility modifiers (e.g., `pub`).
-//!
-//! Note that this only works on structs, as it is not possible to construct an arbitrary enum variant.
 //!
 //! ### `tag_encoding`
 //!

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1582,38 +1582,6 @@ mod tests {
     }
 
     #[test]
-    fn test_uninit_builder_with_mapped_type() {
-        #[derive(Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
-        struct Test {
-            a: Vec<u8>,
-            b: [u8; 32],
-            c: u64,
-        }
-
-        #[derive(UninitBuilder)]
-        #[wincode(internal, from = "Test")]
-        #[allow(unused)]
-        struct TestMapped {
-            a: containers::Vec<u8, BincodeLen>,
-            b: [u8; 32],
-            c: u64,
-        }
-
-        proptest!(proptest_cfg(), |(test: Test)| {
-            let mut uninit = MaybeUninit::<Test>::uninit();
-            let mut builder = TestMappedUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
-            builder
-                .write_a(test.a.clone())
-                .write_b(test.b)
-                .write_c(test.c);
-            prop_assert!(builder.is_init());
-            builder.finish();
-            let init = unsafe { uninit.assume_init() };
-            prop_assert_eq!(test, init);
-        });
-    }
-
-    #[test]
     fn test_uninit_builder_builder_fully_initialized() {
         #[derive(SchemaWrite, UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]


### PR DESCRIPTION
This was useful before wincode got traction and integration with the solana-sdk, but now we're maintaining (nontrivial) functionality that simply isn't used anywhere inside our suite of projects. Potentially unfortunate for some downstream users (though frankly the use-case is quite niche, so I doubt it's actually used extensively in the wild), but removing eliminates a whole set of maintenance burden for us.

