### PR TITLE
chore(derive): remove struct_extensions attribute

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -495,11 +495,6 @@ pub(crate) struct SchemaArgs {
     /// Otherwise, it will use the `wincode` path.
     #[darling(default)]
     pub(crate) internal: bool,
-    /// Specifies whether to generate placement initialization struct helpers on `SchemaRead` implementations.
-    ///
-    /// DEPRECATED; use `#[derive(UninitBuilder)]` instead.
-    #[darling(default)]
-    pub(crate) struct_extensions: bool,
     /// Specifies the encoding to use for enum discriminants.
     ///
     /// If specified, the enum discriminants will be encoded using the given type's `SchemaWrite`

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -5,14 +5,13 @@ use {
             Field, FieldsExt, GenericField, SchemaArgs, StructRepr, TraitImpl, TypeExt, Variant,
             VariantsExt, default_tag_encoding, extract_repr, generic_field_types, get_crate_name,
         },
-        uninit_builder::impl_uninit_builder,
     },
     darling::{
         Error, FromDeriveInput, Result,
         ast::{Data, Fields, Style},
     },
     proc_macro2::{Literal, TokenStream},
-    quote::{quote, quote_spanned},
+    quote::quote,
     syn::{
         DeriveInput, GenericParam, Generics, Path, PredicateType, Token, Type, WhereClause,
         WherePredicate, parse_quote, punctuated::Punctuated,
@@ -410,23 +409,6 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let struct_extensions = if args.struct_extensions {
-        let tokens = impl_uninit_builder(&args, &crate_name)?;
-        let deprecation = quote_spanned! {args.ident.span()=>
-            const _: () = {
-                #[deprecated(note = "#[wincode(struct_extensions)] is deprecated; use #[derive(UninitBuilder)] instead")]
-                const __WINCODE_STRUCT_EXTENSIONS_DEPRECATED: () = ();
-                const _: () = __WINCODE_STRUCT_EXTENSIONS_DEPRECATED;
-            };
-        };
-
-        quote! {
-            #deprecation
-            #tokens
-        }
-    } else {
-        quote!()
-    };
     let zero_copy_asserts = assert_zero_copy(&args, &repr)?;
 
     let (read_impl, type_meta_impl) = match &args.data {
@@ -531,6 +513,5 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
             }
         };
         #zero_copy_asserts
-        #struct_extensions
     })
 }

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -240,7 +240,6 @@
 //! ## Top level
 //! |Attribute|Type|Default|Description
 //! |---|---|---|---|
-//! |`struct_extensions` (DEPRECATED)|`bool`|`false`|Generates placement initialization helpers on `SchemaRead` struct implementations. DEPRECATED; Use `#[derive(UninitBuilder)]` instead.|
 //! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
 //! |`assert_zero_copy`|`bool`\|`Path`|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. Can specify a custom config path, will use the [`DefaultConfig`](config::DefaultConfig) if `bool` form is used.|
 //! |`crate`|`Path`|`::wincode`|Specifies the path to the `wincode` crate. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module. The path is emitted as written and resolved from the derive expansion site.|

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1499,10 +1499,11 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn test_struct_extensions_sanity() {
-        #[derive(SchemaWrite, SchemaRead, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
-        #[wincode(internal, struct_extensions)]
+    fn test_uninit_builder_sanity() {
+        #[derive(
+            SchemaWrite, SchemaRead, UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary,
+        )]
+        #[wincode(internal)]
         struct Test {
             a: Vec<u8>,
             b: [u8; 32],


### PR DESCRIPTION
`struct_extensions` was deprecated and replaced by `UninitBuilder`. Let's remove it before 0.6.0