### PR TITLE
fix(UninitBuilder)!: preserve generic declaration order

### DIFF
--- a/wincode-derive/src/uninit_builder.rs
+++ b/wincode-derive/src/uninit_builder.rs
@@ -51,12 +51,6 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         }
     };
     let builder_struct_decl = {
-        // `split_for_impl` will strip default type and const parameters, so we collect them manually
-        // to preserve the declarations on the original struct.
-        let generic_type_params = builder_generics.type_params();
-        let generic_lifetimes = builder_generics.lifetimes();
-        let generic_const = builder_generics.const_params();
-        let where_clause = builder_generics.where_clause.as_ref();
         quote! {
             /// A helper struct that provides convenience methods for reading and writing to a `MaybeUninit` struct
             /// with a bit-set tracking the initialization state of the fields.
@@ -65,7 +59,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
             /// you **must** call `finish` or `into_assume_init_mut` to forget the builder. Otherwise, all the
             /// initialized fields will be dropped when the builder is dropped.
             #[must_use]
-            #vis struct #builder_ident < #(#generic_lifetimes,)* #(#generic_const,)* #(#generic_type_params,)* > #where_clause {
+            #vis struct #builder_ident #builder_impl_generics #builder_where_clause {
                 inner: &'_wincode_inner mut core::mem::MaybeUninit<#builder_dst>,
                 init_set: #builder_bit_set_ty,
                 _config: core::marker::PhantomData<__WincodeConfig>,

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1466,6 +1466,31 @@ mod tests {
     }
 
     #[test]
+    fn test_uninit_builder_with_type_then_const_default_generics() {
+        #[derive(UninitBuilder)]
+        #[wincode(internal)]
+        #[repr(C)]
+        struct Foo<T = u16, const N: usize = 4>
+        where
+            T: Copy,
+        {
+            marker: PhantomData<T>,
+            bytes: [u8; N],
+        }
+
+        let mut uninit = MaybeUninit::<Foo<u16, 4>>::uninit();
+        let mut builder =
+            FooUninitBuilder::<u16, 4, DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+        builder.write_marker(PhantomData).write_bytes([1, 2, 3, 4]);
+        assert!(builder.is_init());
+        builder.finish();
+
+        // SAFETY: Both fields were initialized by the builder before it was finished.
+        let initialized = unsafe { uninit.assume_init() };
+        assert_eq!(initialized.bytes, [1, 2, 3, 4]);
+    }
+
+    #[test]
     fn test_uninit_builder_uninit_ref() {
         #[derive(SchemaWrite, UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]


### PR DESCRIPTION
Fix `UninitBuilder` generation for structs mixing type and const generics via inconsistent ordering.

The builder declaration now uses the same ordered, default-stripped generics as its impl blocks. This prevents generic parameters from being swapped