### PR TITLE
feat(io)!: rework `Reader` trait to be unsafe + required method

### DIFF
--- a/wincode/src/io/cursor.rs
+++ b/wincode/src/io/cursor.rs
@@ -130,20 +130,31 @@ where
     }
 }
 
-impl<'a, T> Reader<'a> for Cursor<T>
+unsafe impl<'a, T> Reader<'a> for Cursor<T>
 where
     T: AsRef<[u8]>,
 {
     const BORROW_KINDS: u8 = BorrowKind::CallSite.mask();
 
     #[inline]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         let src = self.advance_slice_checked(dst.len())?;
         // SAFETY:
         // - `advance_slice_checked` guarantees that `src` is exactly `dst.len()` bytes.
         // - Given Rust's aliasing rules, we can assume that `dst` does not overlap
         //   with the internal buffer.
         unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast(), dst.len()) }
+        Ok(())
+    }
+
+    #[inline]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        let src = self.advance_slice_checked(dst.len())?;
+        // SAFETY:
+        // - `advance_slice_checked` guarantees that `src` is exactly `dst.len()` bytes.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap
+        //   with the internal buffer.
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<u8>(), dst.len()) }
         Ok(())
     }
 
@@ -517,7 +528,7 @@ mod tests {
             let mut cursor = Cursor::new_at(&bytes, pos);
 
             let mut dst = Vec::with_capacity(bytes.len());
-            let res = cursor.copy_into_slice(dst.spare_capacity_mut());
+            let res = cursor.copy_into_uninit_slice(dst.spare_capacity_mut());
             if pos > bytes.len() && !bytes.is_empty() {
                 prop_assert!(matches!(res, Err(ReadError::ReadSizeLimit(x)) if x == bytes.len()));
             } else {
@@ -532,7 +543,7 @@ mod tests {
             let start = cursor.position();
 
             let mut buf: [MaybeUninit::<u8>; 0] = [];
-            cursor.copy_into_slice(&mut buf).unwrap();
+            cursor.copy_into_uninit_slice(&mut buf).unwrap();
             prop_assert_eq!(cursor.position(), start);
 
             unsafe { <Cursor<_> as Reader>::as_trusted_for(&mut cursor, 0) }.unwrap();
@@ -562,7 +573,7 @@ mod tests {
             // Zero-length ops still succeed and do not advance.
             let mut buf: [MaybeUninit::<u8>; 0] = [];
             let start = cursor.position();
-            prop_assert!(cursor.copy_into_slice(&mut buf).is_ok());
+            prop_assert!(cursor.copy_into_uninit_slice(&mut buf).is_ok());
             {
                 let _trusted = unsafe { <Cursor<_> as Reader>::as_trusted_for(&mut cursor, 0) }.unwrap();
             }

--- a/wincode/src/io/mod.rs
+++ b/wincode/src/io/mod.rs
@@ -70,7 +70,29 @@ pub(super) const fn transpose<const N: usize, T>(
 /// - Callers should prefer [`Reader::copy_into_slice`] or `take_*` methods to remain
 ///   compatible with readers that don't support borrowing, if possible.
 /// - Returns [`ReadError::UnsupportedBorrow`] for readers that do not support borrowing.
-pub trait Reader<'a> {
+///
+/// # Performance
+///
+/// The default [`Reader::copy_into_uninit_slice`] implementation initializes
+/// the destination before delegating to [`Reader::copy_into_slice`].
+/// Implementors that can safely write directly into `MaybeUninit<u8>` storage
+/// should override it to avoid this initialization. Such overrides must still
+/// initialize every destination byte before returning `Ok(())`.
+///
+/// # Safety
+///
+/// Implementors must ensure that:
+///
+/// - If `copy_into_uninit_slice` returns `Ok(())`, every element of the
+///   destination has been initialized.
+/// - All safe methods uphold Rust's validity, aliasing, and lifetime rules for
+///   every safe input. Callers are not responsible for proving that destination
+///   buffers do not overlap internal storage.
+/// - References returned by borrowing methods remain valid for their documented
+///   lifetimes.
+/// - Any unchecked reader returned by `as_trusted_for` obeys that method's
+///   documented bounds contract.
+pub unsafe trait Reader<'a> {
     /// Borrow capabilities of this reader.
     ///
     /// A bitmask of [`BorrowKind`] values indicating which kinds of borrows are supported.
@@ -107,7 +129,10 @@ pub trait Reader<'a> {
     fn take_array<const N: usize>(&mut self) -> ReadResult<[u8; N]> {
         let mut ar = MaybeUninit::<[u8; N]>::uninit();
 
-        self.copy_into_slice(transpose(&mut ar))?;
+        self.copy_into_uninit_slice(transpose(&mut ar))?;
+
+        // SAFETY: `copy_into_uninit_slice` returned successfully, which guarantees
+        // every element of `ar` was initialized.
         Ok(unsafe { ar.assume_init() })
     }
 
@@ -176,10 +201,10 @@ pub trait Reader<'a> {
     /// that `n_bytes` window.
     ///
     /// Implementors must:
-    /// - Ensure that either at least `n_bytes` bytes are available backing the
-    ///   returned reader, or return an error.
     /// - Arrange that the returned `Trusted` reader's methods operate within
     ///   that `n_bytes` window (it may buffer or prefetch arbitrarily).
+    /// - Ensure that the returned reader either continues checking its bounds
+    ///   normally or is backed by at least `n_bytes`; otherwise, return an error.
     ///
     /// Note:
     /// - `as_trusted_for` is intended for callers that know they will operate
@@ -260,44 +285,82 @@ pub trait Reader<'a> {
         self
     }
 
-    /// Copy and consume exactly `dst.len()` bytes from the [`Reader`] into `dst`.
+    /// Attempts to copy and consume exactly `dst.len()` bytes.
     ///
-    /// # Safety
-    ///
-    /// - `dst` must not overlap with the internal buffer.
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()>;
+    /// On success, exactly `dst.len()` bytes are consumed and every element of
+    /// `dst` contains the corresponding byte. On error, some bytes may have been
+    /// consumed; `dst` remains initialized, but its contents are unspecified.
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()>;
 
-    /// Copy and consume exactly `size_of::<T>()` bytes from the [`Reader`] into `dst`.
+    /// Attempts to copy and consume exactly `dst.len()` bytes into potentially
+    /// uninitialized storage.
+    ///
+    /// On success, exactly `dst.len()` bytes are consumed and every element of
+    /// `dst` is initialized. On error, some bytes may have been consumed; the
+    /// initialization state and contents of `dst` are unspecified.
+    ///
+    /// The default implementation initializes the destination before calling
+    /// [`Reader::copy_into_slice`]. Implementations may override it to write directly
+    /// into uninitialized storage.
+    ///
+    /// # Implementor requirements
+    ///
+    /// Before returning `Ok(())`, implementations must initialize every element of
+    /// `dst`. This postcondition is required for soundness. Methods such as `take_array`
+    /// treat the entire destination as initialized after `Ok(())`.
+    /// Returning `Ok(())` while any destination byte remains uninitialized may cause undefined behavior.
+    #[inline(always)]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        dst.fill(MaybeUninit::new(0));
+        // SAFETY: Every element is initialized with a valid `u8`, and
+        // `MaybeUninit<u8>` has the same layout as `u8`.
+        let dst = unsafe { transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(dst) };
+        self.copy_into_slice(dst)
+    }
+
+    /// Attempts to copy and consume exactly `size_of::<T>()` bytes from the
+    /// [`Reader`] into `dst`.
     ///
     /// # Safety
     ///
-    /// - `T` must be initialized by reads of `size_of::<T>()` bytes.
-    /// - `dst` must not overlap with the internal buffer.
+    /// - The caller must ensure that, if this method returns `Ok(())`, the bytes
+    ///   copied into `dst` form a valid representation of `T` before `dst` is
+    ///   treated as initialized. This includes all validity and provenance
+    ///   requirements of `T`.
+    /// - The caller must ensure that the memory occupied by `dst` does not overlap
+    ///   the source bytes accessed by the reader.
     #[inline]
     unsafe fn copy_into_t<T>(&mut self, dst: &mut MaybeUninit<T>) -> ReadResult<()> {
-        // SAFETY: Caller ensures that `T` is initialized by reads of `size_of::<T>()` bytes.
+        // SAFETY: `dst` provides `size_of::<T>()` contiguous writable bytes, and
+        // `MaybeUninit<u8>` has alignment 1.
         let dst = unsafe {
             from_raw_parts_mut(dst.as_mut_ptr().cast::<MaybeUninit<u8>>(), size_of::<T>())
         };
-        self.copy_into_slice(dst)
+        self.copy_into_uninit_slice(dst)
     }
 
-    /// Copy and consume exactly `dst.len() * size_of::<T>()` bytes from the [`Reader`] into `dst`.
+    /// Attempts to copy and consume exactly `dst.len() * size_of::<T>()` bytes
+    /// from the [`Reader`] into `dst`.
     ///
     /// # Safety
     ///
-    /// - `T` must be initialized by reads of `size_of::<T>()` bytes.
-    /// - `dst` must not overlap with the internal buffer.
+    /// - The caller must ensure that, if this method returns `Ok(())`, each
+    ///   consecutive `size_of::<T>()` byte region copied into `dst` forms a valid
+    ///   representation of `T` before the elements are treated as initialized.
+    ///   This includes all validity and provenance requirements of `T`.
+    /// - The caller must ensure that the memory occupied by `dst` does not overlap
+    ///   the source bytes accessed by the reader.
     #[inline]
     unsafe fn copy_into_slice_t<T>(&mut self, dst: &mut [MaybeUninit<T>]) -> ReadResult<()> {
         let len = size_of_val(dst);
-        // SAFETY: Caller ensures that `T` is initialized by reads of `size_of::<T>()` bytes.
+        // SAFETY: `dst` provides `size_of_val(dst)` contiguous writable bytes,
+        // and `MaybeUninit<u8>` has alignment 1.
         let dst = unsafe { from_raw_parts_mut(dst.as_mut_ptr().cast::<MaybeUninit<u8>>(), len) };
-        self.copy_into_slice(dst)
+        self.copy_into_uninit_slice(dst)
     }
 }
 
-impl<'a, R: Reader<'a> + ?Sized> Reader<'a> for &mut R {
+unsafe impl<'a, R: Reader<'a> + ?Sized> Reader<'a> for &mut R {
     const BORROW_KINDS: u8 = R::BORROW_KINDS;
 
     #[inline(always)]
@@ -350,8 +413,13 @@ impl<'a, R: Reader<'a> + ?Sized> Reader<'a> for &mut R {
     }
 
     #[inline(always)]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         (*self).copy_into_slice(dst)
+    }
+
+    #[inline(always)]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        (*self).copy_into_uninit_slice(dst)
     }
 
     #[inline(always)]

--- a/wincode/src/io/slice.rs
+++ b/wincode/src/io/slice.rs
@@ -70,20 +70,34 @@ impl<'a, T> SliceUnchecked<'a, T> {
     }
 }
 
-impl<'a> Reader<'a> for SliceUnchecked<'a, u8> {
+unsafe impl<'a> Reader<'a> for SliceUnchecked<'a, u8> {
     const BORROW_KINDS: u8 = BorrowKind::Backing.mask() | BorrowKind::CallSite.mask();
 
     #[inline]
-    fn copy_into_slice(&mut self, buf: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         // SAFETY: by constructing `SliceUnchecked`, caller guarantees
         // they will read within the bounds of the slice.
-        let chunk = unsafe { advance_slice_unchecked(&mut self.buf, buf.len()) };
+        let chunk = unsafe { advance_slice_unchecked(&mut self.buf, dst.len()) };
         // SAFETY:
         // -  Given the previous assumption that the caller guarantees the underlying
-        //    slice in bounds for the next `buf.len()` bytes, we assume that `chunk` is a valid,
-        //    in bounds, `buf.len()` bytes slice.
-        // - Given Rust's aliasing rules, we can assume that `buf` does not overlap with the internal buffer.
-        unsafe { copy_nonoverlapping(chunk.as_ptr(), buf.as_mut_ptr().cast(), buf.len()) };
+        //    slice in bounds for the next `dst.len()` bytes, we assume that `chunk` is a valid,
+        //    in bounds, `dst.len()` bytes slice.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap with the internal buffer.
+        unsafe { copy_nonoverlapping(chunk.as_ptr(), dst.as_mut_ptr(), dst.len()) };
+        Ok(())
+    }
+
+    #[inline]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        // SAFETY: by constructing `SliceUnchecked`, caller guarantees
+        // they will read within the bounds of the slice.
+        let chunk = unsafe { advance_slice_unchecked(&mut self.buf, dst.len()) };
+        // SAFETY:
+        // -  Given the previous assumption that the caller guarantees the underlying
+        //    slice in bounds for the next `dst.len()` bytes, we assume that `chunk` is a valid,
+        //    in bounds, `dst.len()` bytes slice.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap with the internal buffer.
+        unsafe { copy_nonoverlapping(chunk.as_ptr(), dst.as_mut_ptr().cast::<u8>(), dst.len()) };
         Ok(())
     }
 
@@ -153,21 +167,35 @@ impl<'a, T> SliceMutUnchecked<'a, T> {
     }
 }
 
-impl<'a> Reader<'a> for SliceMutUnchecked<'a, u8> {
+unsafe impl<'a> Reader<'a> for SliceMutUnchecked<'a, u8> {
     const BORROW_KINDS: u8 =
         BorrowKind::Backing.mask() | BorrowKind::BackingMut.mask() | BorrowKind::CallSite.mask();
 
     #[inline]
-    fn copy_into_slice(&mut self, buf: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         // SAFETY: by constructing `SliceMutUnchecked`, caller guarantees
         // they will read within the bounds of the slice.
-        let chunk = unsafe { advance_slice_mut_unchecked(&mut self.buf, buf.len()) };
+        let chunk = unsafe { advance_slice_mut_unchecked(&mut self.buf, dst.len()) };
         // SAFETY:
         // -  Given the previous assumption that the caller guarantees the underlying
-        //    slice in bounds for the next `buf.len()` bytes, we assume that `chunk` is a valid,
-        //    in bounds, `buf.len()` bytes slice.
-        // - Given Rust's aliasing rules, we can assume that `buf` does not overlap with the internal buffer.
-        unsafe { copy_nonoverlapping(chunk.as_ptr(), buf.as_mut_ptr().cast(), buf.len()) };
+        //    slice in bounds for the next `dst.len()` bytes, we assume that `chunk` is a valid,
+        //    in bounds, `dst.len()` bytes slice.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap with the internal buffer.
+        unsafe { copy_nonoverlapping(chunk.as_ptr(), dst.as_mut_ptr(), dst.len()) };
+        Ok(())
+    }
+
+    #[inline]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        // SAFETY: by constructing `SliceMutUnchecked`, caller guarantees
+        // they will read within the bounds of the slice.
+        let chunk = unsafe { advance_slice_mut_unchecked(&mut self.buf, dst.len()) };
+        // SAFETY:
+        // -  Given the previous assumption that the caller guarantees the underlying
+        //    slice in bounds for the next `dst.len()` bytes, we assume that `chunk` is a valid,
+        //    in bounds, `dst.len()` bytes slice.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap with the internal buffer.
+        unsafe { copy_nonoverlapping(chunk.as_ptr(), dst.as_mut_ptr().cast::<u8>(), dst.len()) };
         Ok(())
     }
 
@@ -226,12 +254,17 @@ impl<'b, T> SliceScopedUnchecked<'_, 'b, T> {
     }
 }
 
-impl<'a> Reader<'a> for SliceScopedUnchecked<'a, '_, u8> {
+unsafe impl<'a> Reader<'a> for SliceScopedUnchecked<'a, '_, u8> {
     const BORROW_KINDS: u8 = BorrowKind::CallSite.mask();
 
     #[inline(always)]
-    fn copy_into_slice(&mut self, buf: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
-        self.inner.copy_into_slice(buf)
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
+        self.inner.copy_into_slice(dst)
+    }
+
+    #[inline(always)]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        self.inner.copy_into_uninit_slice(dst)
     }
 
     #[inline(always)]
@@ -245,7 +278,7 @@ impl<'a> Reader<'a> for SliceScopedUnchecked<'a, '_, u8> {
     }
 }
 
-impl<'a> Reader<'a> for &'a [u8] {
+unsafe impl<'a> Reader<'a> for &'a [u8] {
     const BORROW_KINDS: u8 = BorrowKind::Backing.mask() | BorrowKind::CallSite.mask();
 
     #[inline]
@@ -262,7 +295,7 @@ impl<'a> Reader<'a> for &'a [u8] {
     }
 
     #[inline]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         let Some(src) = advance_slice_checked(self, dst.len()) else {
             return Err(read_size_limit(dst.len()));
         };
@@ -270,7 +303,20 @@ impl<'a> Reader<'a> for &'a [u8] {
         // - `advance_slice_checked` guarantees that `src` is exactly `dst.len()` bytes.
         // - Given Rust's aliasing rules, we can assume that `dst` does not overlap
         //   with the internal buffer.
-        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast(), dst.len()) };
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), dst.len()) };
+        Ok(())
+    }
+
+    #[inline]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        let Some(src) = advance_slice_checked(self, dst.len()) else {
+            return Err(read_size_limit(dst.len()));
+        };
+        // SAFETY:
+        // - `advance_slice_checked` guarantees that `src` is exactly `dst.len()` bytes.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap
+        //   with the internal buffer.
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<u8>(), dst.len()) };
         Ok(())
     }
 
@@ -294,7 +340,7 @@ impl<'a> Reader<'a> for &'a [u8] {
     }
 }
 
-impl<'a> Reader<'a> for &'a mut [u8] {
+unsafe impl<'a> Reader<'a> for &'a mut [u8] {
     const BORROW_KINDS: u8 =
         BorrowKind::Backing.mask() | BorrowKind::BackingMut.mask() | BorrowKind::CallSite.mask();
 
@@ -327,12 +373,22 @@ impl<'a> Reader<'a> for &'a mut [u8] {
     }
 
     #[inline]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         let src = self.take_borrowed(dst.len())?;
         // SAFETY:
-        // - `borrow_exact` guarantees that `src` is exactly dst.len() bytes.
-        // - Given Rust's aliasing rules, we can assume that `buf` does not overlap with the internal buffer.
-        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast(), dst.len()) }
+        // - `take_borrowed` guarantees that `src` is exactly `dst.len()` bytes.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap with the internal buffer.
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), dst.len()) }
+        Ok(())
+    }
+
+    #[inline]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        let src = self.take_borrowed(dst.len())?;
+        // SAFETY:
+        // - `take_borrowed` guarantees that `src` is exactly `dst.len()` bytes.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap with the internal buffer.
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<u8>(), dst.len()) }
         Ok(())
     }
 
@@ -354,7 +410,7 @@ impl Writer for SliceMutUnchecked<'_, u8> {
         let dst = unsafe { advance_slice_mut_unchecked(&mut self.buf, src.len()) };
         // SAFETY:
         // -  Given the previous assumption that the caller guarantees the underlying
-        //    slice in bounds for the next `buf.len()` bytes, we assume that `dst` is a valid,
+        //    slice in bounds for the next `src.len()` bytes, we assume that `dst` is a valid,
         //    in bounds, `src.len()` bytes slice.
         // - Given Rust's aliasing rules, we can assume that `src` does not overlap with the internal buffer.
         unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast(), src.len()) }
@@ -370,7 +426,7 @@ impl Writer for SliceMutUnchecked<'_, MaybeUninit<u8>> {
         let dst = unsafe { advance_slice_mut_unchecked(&mut self.buf, src.len()) };
         // SAFETY:
         // -  Given the previous assumption that the caller guarantees the underlying
-        //    slice in bounds for the next `buf.len()` bytes, we assume that `dst` is a valid,
+        //    slice in bounds for the next `src.len()` bytes, we assume that `dst` is a valid,
         //    in bounds, `src.len()` bytes slice.
         // - Given Rust's aliasing rules, we can assume that `src` does not overlap with the internal buffer.
         unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast(), src.len()) }
@@ -527,17 +583,36 @@ mod tests {
 
         #[test]
         fn test_reader_copy_into_slice(bytes in any::<Vec<u8>>()) {
+            let len = bytes.len();
             with_readers!(&bytes, |reader| {
-                let mut vec = Vec::with_capacity(bytes.len());
-                let half = bytes.len() / 2;
-                let dst = vec.spare_capacity_mut();
+                let mut dst = alloc::vec![0; len];
+                let half = len / 2;
                 reader.copy_into_slice(&mut dst[..half]).unwrap();
-                unsafe { reader.as_trusted_for(bytes.len() - half) }
+                // SAFETY: the returned reader is used to read exactly the requested number of bytes.
+                unsafe { Reader::as_trusted_for(&mut reader, len - half) }
                     .unwrap()
                     .copy_into_slice(&mut dst[half..])
                     .unwrap();
-                unsafe { vec.set_len(bytes.len()) };
-                prop_assert_eq!(&vec, &bytes);
+                prop_assert_eq!(&dst, &bytes);
+            });
+        }
+
+        #[test]
+        fn test_reader_copy_into_uninit_slice(bytes in any::<Vec<u8>>()) {
+            let len = bytes.len();
+            with_readers!(&bytes, |reader| {
+                let mut dst = Vec::with_capacity(len);
+                let half = len / 2;
+                let spare = dst.spare_capacity_mut();
+                reader.copy_into_uninit_slice(&mut spare[..half]).unwrap();
+                // SAFETY: the returned reader is used to read exactly the requested number of bytes.
+                unsafe { Reader::as_trusted_for(&mut reader, len - half) }
+                    .unwrap()
+                    .copy_into_uninit_slice(&mut spare[half..])
+                    .unwrap();
+                // SAFETY: both copy operations succeeded and initialized every byte in the allocation.
+                unsafe { dst.set_len(len) };
+                prop_assert_eq!(&dst, &bytes);
             });
         }
 
@@ -558,10 +633,19 @@ mod tests {
 
         #[test]
         fn test_reader_copy_into_slice_input_too_large(bytes in any::<Vec<u8>>()) {
+            let requested = bytes.len() + 1;
             with_untrusted_readers!(&bytes, |reader| {
-                let mut vec = Vec::with_capacity(bytes.len() + 1);
-                let dst = vec.spare_capacity_mut();
-                prop_assert!(matches!(reader.copy_into_slice(dst), Err(ReadError::ReadSizeLimit(x)) if x == bytes.len() + 1));
+                let mut dst = alloc::vec![0; requested];
+                prop_assert!(matches!(reader.copy_into_slice(&mut dst), Err(ReadError::ReadSizeLimit(x)) if x == requested));
+            });
+        }
+
+        #[test]
+        fn test_reader_copy_into_uninit_slice_input_too_large(bytes in any::<Vec<u8>>()) {
+            let requested = bytes.len() + 1;
+            with_untrusted_readers!(&bytes, |reader| {
+                let mut dst = Vec::with_capacity(requested);
+                prop_assert!(matches!(reader.copy_into_uninit_slice(dst.spare_capacity_mut()), Err(ReadError::ReadSizeLimit(x)) if x == requested));
             });
         }
 

--- a/wincode/src/io/std_read.rs
+++ b/wincode/src/io/std_read.rs
@@ -1,9 +1,6 @@
 use {
     crate::io::{BorrowKind, ReadResult, Reader, read_size_limit, slice::SliceScopedUnchecked},
-    core::{
-        mem::{MaybeUninit, transmute},
-        ptr::copy_nonoverlapping,
-    },
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping},
     std::io::{self, BufReader, Cursor, Read},
 };
 
@@ -34,10 +31,7 @@ impl<R: Read> ReadAdapter<R> {
 }
 
 #[inline]
-fn copy_into_slice<R: Read + ?Sized>(
-    reader: &mut R,
-    dst: &mut [MaybeUninit<u8>],
-) -> ReadResult<()> {
+fn copy_into_slice<R: Read + ?Sized>(reader: &mut R, dst: &mut [u8]) -> ReadResult<()> {
     #[cold]
     fn maybe_eof_to_read_size_limit(err: io::Error, len: usize) -> ReadResult<()> {
         if err.kind() == io::ErrorKind::UnexpectedEof {
@@ -46,25 +40,22 @@ fn copy_into_slice<R: Read + ?Sized>(
             Err(err.into())
         }
     }
-
-    // SAFETY: `read_exact` only writes to the buffer.
-    let buf = unsafe { transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(dst) };
-    if let Err(e) = reader.read_exact(buf) {
-        return maybe_eof_to_read_size_limit(e, buf.len());
+    if let Err(e) = reader.read_exact(dst) {
+        return maybe_eof_to_read_size_limit(e, dst.len());
     };
     Ok(())
 }
 
-impl<R: Read + ?Sized> Reader<'_> for ReadAdapter<R> {
+unsafe impl<R: Read + ?Sized> Reader<'_> for ReadAdapter<R> {
     #[inline(always)]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         copy_into_slice(&mut self.0, dst)
     }
 }
 
-impl<R: Read + ?Sized> Reader<'_> for BufReader<R> {
+unsafe impl<R: Read + ?Sized> Reader<'_> for BufReader<R> {
     #[inline(always)]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         copy_into_slice(self, dst)
     }
 }
@@ -86,20 +77,31 @@ fn cursor_advance(cursor: &mut Cursor<impl AsRef<[u8]>>, n: usize) -> ReadResult
     Ok(&inner[pos..next_pos])
 }
 
-impl<'a, T> Reader<'a> for Cursor<T>
+unsafe impl<'a, T> Reader<'a> for Cursor<T>
 where
     T: AsRef<[u8]>,
 {
     const BORROW_KINDS: u8 = BorrowKind::CallSite.mask();
 
     #[inline]
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         let src = cursor_advance(self, dst.len())?;
         // SAFETY:
         // - `cursor_advance` guarantees that `src` is exactly `dst.len()` bytes.
         // - Given Rust's aliasing rules, we can assume that `dst` does not overlap
         //   with the internal buffer.
-        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast(), dst.len()) };
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), dst.len()) };
+        Ok(())
+    }
+
+    #[inline]
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        let src = cursor_advance(self, dst.len())?;
+        // SAFETY:
+        // - `cursor_advance` guarantees that `src` is exactly `dst.len()` bytes.
+        // - Given Rust's aliasing rules, we can assume that `dst` does not overlap
+        //   with the internal buffer.
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<u8>(), dst.len()) };
         Ok(())
     }
 
@@ -124,5 +126,67 @@ where
         // SAFETY: by calling `as_trusted_for`, caller guarantees they
         // will will not read beyond the bounds of the slice, `n_bytes`.
         Ok(unsafe { SliceScopedUnchecked::new(buf) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A safe `Read` implementation that inspects the destination before writing.
+    ///
+    /// This catches adapters passing uninitialized storage to `Read::read`: inspecting
+    /// such storage would trigger undefined behavior under Miri.
+    struct InspectingReader {
+        data: Vec<u8>,
+        pos: usize,
+        observed: Vec<u8>,
+    }
+
+    impl InspectingReader {
+        fn new(data: Vec<u8>) -> Self {
+            Self {
+                data,
+                pos: 0,
+                observed: Vec::new(),
+            }
+        }
+    }
+
+    impl Read for InspectingReader {
+        fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+            self.observed.extend_from_slice(dst);
+
+            let remaining = &self.data[self.pos..];
+            let len = dst.len().min(remaining.len());
+            dst[..len].copy_from_slice(&remaining[..len]);
+            self.pos = self.pos.checked_add(len).unwrap();
+            Ok(len)
+        }
+    }
+
+    #[test]
+    fn read_adapter_initializes_destination_before_reading() {
+        let expected = 0x0123_4567_89ab_cdef_u64;
+        let data = crate::serialize(&expected).unwrap();
+        let mut reader = InspectingReader::new(data.clone());
+
+        let actual: u64 = crate::deserialize_from(ReadAdapter::new(&mut reader)).unwrap();
+
+        assert_eq!(actual, expected);
+        assert_eq!(reader.observed, vec![0; data.len()]);
+    }
+
+    #[test]
+    fn buf_reader_initializes_destination_before_reading() {
+        let expected = 0x0123_4567_89ab_cdef_u64;
+        let data = crate::serialize(&expected).unwrap();
+        let mut reader = InspectingReader::new(data.clone());
+
+        let actual: u64 =
+            crate::deserialize_from(BufReader::with_capacity(1, &mut reader)).unwrap();
+
+        assert_eq!(actual, expected);
+        assert_eq!(reader.observed, vec![0; data.len()]);
     }
 }

--- a/wincode/src/io/test_util.rs
+++ b/wincode/src/io/test_util.rs
@@ -17,8 +17,12 @@ impl<'a> NoBorrowReader<'a> {
     }
 }
 
-impl Reader<'_> for NoBorrowReader<'_> {
-    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+unsafe impl Reader<'_> for NoBorrowReader<'_> {
+    fn copy_into_slice(&mut self, dst: &mut [u8]) -> ReadResult<()> {
         self.inner.copy_into_slice(dst)
+    }
+
+    fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
+        self.inner.copy_into_uninit_slice(dst)
     }
 }

--- a/wincode/src/schema/external/ecow.rs
+++ b/wincode/src/schema/external/ecow.rs
@@ -42,16 +42,16 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for EcoString {
 
         if len <= EcoString::INLINE_LIMIT {
             let mut buf = [MaybeUninit::uninit(); EcoString::INLINE_LIMIT];
-            reader.copy_into_slice(&mut buf[..len])?;
-            // SAFETY: `copy_into_slice` initialized the first `len` bytes of `buf`.
+            reader.copy_into_uninit_slice(&mut buf[..len])?;
+            // SAFETY: `copy_into_uninit_slice` initialized the first `len` bytes of `buf`.
             let bytes = unsafe { core::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), len) };
             let string = str::from_utf8(bytes).map_err(invalid_utf8_encoding)?;
             dst.write(EcoString::from(string));
             Ok(())
         } else {
             let mut bytes = Vec::with_capacity(len);
-            reader.copy_into_slice(&mut bytes.spare_capacity_mut()[..len])?;
-            // SAFETY: `copy_into_slice` fills the entire spare-capacity slice.
+            reader.copy_into_uninit_slice(&mut bytes.spare_capacity_mut()[..len])?;
+            // SAFETY: `copy_into_uninit_slice` fills the entire spare-capacity slice.
             unsafe { bytes.set_len(len) };
             let string = str::from_utf8(&bytes).map_err(invalid_utf8_encoding)?;
             dst.write(EcoString::from(string));


### PR DESCRIPTION
This PR proposes two changes to the `Reader` trait.

### `Reader` becomes an `unsafe trait`.

The current required method is `copy_into_slice`, which has the following signature:
```rs
fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()>;
```

Safe code relies on this method fully initializing the `dst` on success, but this postcondition is never encoded as a safety obligation.

As such, this PR updates the `Reader` trait to be `unsafe` to implement, and specifies that initialization post-condition explicitly under its safety contract.

### `Reader`'s required method, `copy_into_slice`, now accepts `&mut [u8]`.

This turns out to be the better default than `&mut [MaybeUninit<u8>]`. 

Often times, user code will have access to a `&mut [u8]`, but cannot use `copy_into_slice` without using either `from_raw_parts_mut` or `transmute` on it, which is poor ergonomics. Furthermore, this conversion is lossy at the type level -- the given slice may initialized, but downstream code must treat it as uninitialized, which can result in double initialization. For example, consider the std io `ReadAdapter` (abridged):

```rs
impl<R: Read + ?Sized> Reader<'_> for ReadAdapter<R> {
    #[inline(always)]
    fn copy_into_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
        // Choice here -- do we assume that `R: Read` doesn't read the contents of `dst`, or 
        // explicitly zero-initialize?
        //
        // Choice 1: assume `R: Read` doesn't read the contents (potentially exposing uninit mem)
        let buf = unsafe { transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(dst) };
        // Choice 2: make no assumptions, zero-initialize the `dst`
        buf.fill(MaybeUninit::new(0));

        if let Err(e) = reader.read_exact(buf) {
            return maybe_eof_to_read_size_limit(e, buf.len());
        };
        Ok(())
    }
}
```

Now consider the calling code:
```rs
let mut reader = ReadAdapter::new(/* */);
let mut buf = [0u8; 32];
// Cannot pass `buf` directly.
let dst = unsafe { transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(buf.as_mut_slice()) };
reader.copy_into_slice(dst);
```

If `ReadAdapter` chooses to zero initialize `dst` (choice 2), the already zeroed `buf` is zeroed again.

`copy_into_slice` accepting `&mut [u8]` resolves this completely.

This PR makes this adjustment, and additionally exposes `copy_into_uninit_slice`, which has the same signature as the current `copy_into_slice`. By default, it zeroes the given buffer and delegates to `copy_into_slice`.

```rs
fn copy_into_uninit_slice(&mut self, dst: &mut [MaybeUninit<u8>]) -> ReadResult<()> {
    dst.fill(MaybeUninit::new(0));
    // SAFETY: Every element is initialized with a valid `u8`, and
    // `MaybeUninit<u8>` has the same layout as `u8`.
    let dst = unsafe { transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(dst) };
    self.copy_into_slice(dst)
}
```

Implementations that can support writing directly into uninitialized storage are updated to do so.