### PR TITLE
perf(schema): decode SmallVec in place to avoid large stack temporary

### DIFF
--- a/wincode/src/schema/external/smallvec.rs
+++ b/wincode/src/schema/external/smallvec.rs
@@ -38,15 +38,41 @@ where
     #[inline]
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         let len = C::LengthEncoding::read_prealloc_check::<T::Dst>(reader.by_ref())?;
-        let mut values = SmallVec::with_capacity(len);
-        let ptr: *mut T::Dst = values.as_mut_ptr();
-        // SAFETY: `values` has capacity for `len` elements and `decode_into_slice_t`
-        // initializes all elements on success.
+
+        // Reserve capacity through `dst` in place. Moving a `SmallVec::with_capacity(len)`
+        // local into `dst` would memcpy its whole `[T::Dst; N]` inline region;
+        // building empty in `dst` and growing in place leaves that region uninit.
+        let values = dst.write(SmallVec::new());
+        values.reserve_exact(len);
+
+        // `dst` now owns a reserved (possibly heap) allocation, but the caller
+        // still treats it as uninitialized and will not drop it. Free it on any
+        // early exit -- an `Err` return *or* a panic while decoding -- so the
+        // allocation cannot leak. The guard is disarmed only once `dst` holds the
+        // fully initialized value.
+        struct Guard<'a, U>(&'a mut MaybeUninit<U>);
+        impl<U> Drop for Guard<'_, U> {
+            fn drop(&mut self) {
+                // SAFETY: the guard is only live while `dst` holds an empty
+                // `SmallVec` (length 0 until the guard is disarmed), so this drops
+                // just the reserved allocation, never any element.
+                unsafe { self.0.assume_init_drop() };
+            }
+        }
+        let guard = Guard(dst);
+
+        // SAFETY: `dst` was initialized with the empty `SmallVec` above.
+        let ptr: *mut T::Dst = unsafe { guard.0.assume_init_mut() }.as_mut_ptr();
+        // SAFETY: the buffer has capacity for `len` elements. On error (or panic)
+        // `decode_into_slice_t` drops any elements it initialized; on success it
+        // initializes all `len` of them.
         let slice = unsafe { from_raw_parts_mut(ptr.cast::<MaybeUninit<T::Dst>>(), len) };
         decode_into_slice_t::<T, C>(reader, slice)?;
+
         // SAFETY: `decode_into_slice_t` initialized all `len` elements on success.
-        unsafe { values.set_len(len) };
-        dst.write(values);
+        unsafe { guard.0.assume_init_mut().set_len(len) };
+        // `dst` now fully owns the value; keep it rather than dropping via `guard`.
+        core::mem::forget(guard);
         Ok(())
     }
 }

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1214,6 +1214,27 @@ mod tests {
         });
     }
 
+    /// Test that reading a `SmallVec` drops the elements it initialized before an
+    /// error (via `SliceDropGuard`) and frees the reserved backing allocation
+    /// (via the in-place guard in the `SchemaRead` impl). The element leak is
+    /// caught by `TLDropGuard`; the allocation leak is only caught under Miri.
+    #[cfg(feature = "smallvec")]
+    #[test]
+    fn test_smallvec_handles_partial_drop() {
+        use smallvec::SmallVec;
+        // Inline capacity spans both the inline (`len <= 4`) and spilled cases.
+        type SmallVec4<T> = SmallVec<[T; 4]>;
+
+        let _guard = TLDropGuard::new();
+        proptest!(proptest_cfg(), |(vec in proptest::collection::vec(any::<DropCountedMaybeError>(), 0..16).prop_map(SmallVec4::from_vec))| {
+            let serialized = serialize(&vec).unwrap();
+            let deserialized = <SmallVec4<DropCountedMaybeError>>::deserialize(&serialized);
+            if let Ok(deserialized) = deserialized {
+                prop_assert_eq!(vec, deserialized);
+            }
+        });
+    }
+
     #[test]
     fn test_vec_deque_handles_partial_drop() {
         let _guard = TLDropGuard::new();


### PR DESCRIPTION
#### Problem
The SmallVec `SchemaRead` impl built a `SmallVec<[T::Dst; N]>` local,
decoded into it, then moved it into `dst`. Because a SmallVec's size
embeds its `[T::Dst; N]` inline buffer, both the initial move of the
with-capacity local and the final move into `dst` memcpy'd the whole
inline region through the stack -- costly for a large inline capacity
`N`, and confirmed as a fixed-size memcpy in release codegen.

#### Summary of Changes
Build an empty `SmallVec` directly in `dst`, grow it in place with
`reserve_exact`, and decode into its own buffer, so the inline region is
never copied. A small RAII guard frees the reserved allocation on any
early exit -- an `Err` return or a panic while decoding -- and is
disarmed once `dst` owns the finalized value.

#### Testing
Add `test_smallvec_handles_partial_drop` (mirroring the Vec test) over a
range spanning the inline and spilled cases; verified clean under Miri.
