### PR TITLE
fix(UninitBuilder)!: bound read_<field> reader lifetime to outlive struct

### DIFF
--- a/wincode-derive/src/uninit_builder.rs
+++ b/wincode-derive/src/uninit_builder.rs
@@ -148,6 +148,16 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         }
     };
 
+    // The reader lifetime `'de` used by `read_<field>` must outlive every lifetime the
+    // destination struct is generic over. Otherwise a reader borrowing shorter-lived data
+    // could be stored into a longer-lived (e.g. `'static`) borrowed field.
+    let struct_lifetimes: Vec<_> = args.generics.lifetimes().map(|lt| &lt.lifetime).collect();
+    let read_de_bound = if struct_lifetimes.is_empty() {
+        quote!()
+    } else {
+        quote!(where #('de: #struct_lifetimes),*)
+    };
+
     // Generate the helper methods for the builder.
     let builder_helpers = fields.iter().enumerate().map(|(i, field)| {
         let ty = &field.ty;
@@ -213,7 +223,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
 
             /// Read a value from the reader into the maybe uninitialized field.
             #[inline]
-            #vis fn #read_field_ident <'de>(&mut self, reader: impl #crate_name::io::Reader<'de>) -> #crate_name::ReadResult<&mut Self> {
+            #vis fn #read_field_ident <'de>(&mut self, reader: impl #crate_name::io::Reader<'de>) -> #crate_name::ReadResult<&mut Self> #read_de_bound {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
                 // - We return the field as `&mut MaybeUninit<#target>`, so

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -78,3 +78,34 @@ fn derive_tag_uniqueness_repr_normalization() {}
 /// # }
 /// ```
 fn derive_tag_uniqueness_implicit_collision() {}
+
+/// A `read_<field>` on an `UninitBuilder` must not launder the reader lifetime: reading
+/// from a short-lived reader into a longer-lived borrowed field (here `'static`) would
+/// leave a dangling reference after `assume_init`. The `'de: 'a` bound rejects it.
+///
+/// The matching positive case (a reader that outlives the borrowed field) is covered by
+/// `test_uninit_builder_read_borrowed` in `schema::tests`.
+///
+/// ```compile_fail
+/// # #[cfg(all(feature = "derive"))] {
+/// use {core::mem::MaybeUninit, wincode::config::DefaultConfig};
+///
+/// #[derive(wincode::UninitBuilder)]
+/// struct Borrowed<'a> {
+///     data: &'a [u8],
+/// }
+///
+/// fn launder() -> Borrowed<'static> {
+///     let mut uninit = MaybeUninit::<Borrowed<'static>>::uninit();
+///     {
+///         let short_lived: Vec<u8> = vec![3, 0, 0, 0, 0, 0, 0, 0, 0xAA, 0xBB, 0xCC];
+///         let mut builder =
+///             BorrowedUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+///         builder.read_data(short_lived.as_slice()).unwrap();
+///         builder.finish();
+///     }
+///     unsafe { uninit.assume_init() }
+/// }
+/// # }
+/// ```
+fn uninit_builder_read_forbids_lifetime_launder() {}

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1607,6 +1607,40 @@ mod tests {
         });
     }
 
+    // Reading borrowed fields from a longer-lived reader is sound; the `'de: 'a` bound only
+    // rejects the reverse (see the `uninit_builder_read_forbids_lifetime_launder` doctest).
+    #[test]
+    fn test_uninit_builder_read_borrowed() {
+        #[derive(SchemaWrite, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
+        #[wincode(internal)]
+        struct Test {
+            a: Vec<u8>,
+            b: Option<String>,
+        }
+
+        #[derive(UninitBuilder, Debug, PartialEq, Eq)]
+        #[wincode(internal)]
+        struct TestRef<'a> {
+            a: &'a [u8],
+            b: Option<&'a str>,
+        }
+
+        proptest!(proptest_cfg(), |(test: Test)| {
+            let serialized = serialize(&test).unwrap();
+            let mut uninit = MaybeUninit::<TestRef>::uninit();
+            let mut reader = serialized.as_slice();
+            let mut builder = TestRefUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+            // `reader` (borrowing `serialized`) outlives `uninit`, so `read_<field>` is allowed.
+            builder
+                .read_a(reader.by_ref())?
+                .read_b(reader.by_ref())?;
+            prop_assert!(builder.is_init());
+            let init = unsafe { builder.into_assume_init_mut() };
+            prop_assert_eq!(test.a.as_slice(), init.a);
+            prop_assert_eq!(test.b.as_deref(), init.b);
+        });
+    }
+
     #[test]
     fn test_uninit_builder_builder_fully_initialized() {
         #[derive(SchemaWrite, UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]


### PR DESCRIPTION
#### Problem
The generated read_<field> introduced an unconstrained reader lifetime `'de` and cast the field slot, letting a short-lived borrow be stored into a longer-lived (e.g. `'static`) field and dangle after `assume_init`.

#### Summary of Changes
Require `'de` to outlive every struct lifetime. 

#### Testing
Adds a compile-fail doctest for the launder and a runtime test for the sound (longer-lived reader) case.
