### PR TITLE
fix(SystemTime): validate value in size_of to match write

### DIFF
--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -1719,15 +1719,10 @@ unsafe impl<C: ConfigCore> SchemaWrite<C> for SystemTime {
 
     #[inline]
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        match <Self as SchemaWrite<C>>::TYPE_META {
-            TypeMeta::Static { size, .. } => Ok(size),
-            TypeMeta::Dynamic => {
-                let duration = src.duration_since(UNIX_EPOCH).map_err(|_| {
-                    crate::error::WriteError::Custom("SystemTime before UNIX_EPOCH")
-                })?;
-                <Duration as SchemaWrite<C>>::size_of(&duration)
-            }
-        }
+        let duration = src
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| crate::error::WriteError::Custom("SystemTime before UNIX_EPOCH"))?;
+        <Duration as SchemaWrite<C>>::size_of(&duration)
     }
 
     #[inline]

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -3889,6 +3889,9 @@ mod tests {
 
         let before_epoch = UNIX_EPOCH.checked_sub(Duration::from_secs(1)).unwrap();
         assert!(serialize(&before_epoch).is_err());
+        // `serialized_size` must agree with `serialize`: a value that cannot be
+        // written must not report a size.
+        assert!(crate::serialized_size(&before_epoch).is_err());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
`size_of` took the static `TYPE_META` branch and returned `Ok` without validating, so `serialized_size` accepted pre-`UNIX_EPOCH` values that serialize rejects.

#### Summary of Changes
Always validate `duration_since(UNIX_EPOCH)`.

#### Testing
Extend test with above case.