### PR TITLE
fix(UninitBuilder)!: enforce exact field types in projections

### DIFF
--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -86,9 +86,6 @@ pub(crate) trait TypeExt {
     /// ```
     fn with_infer(&self, infer: &Type) -> Type;
 
-    /// Gather all the lifetimes on this type.
-    fn lifetimes(&self) -> Vec<&Lifetime>;
-
     /// Return whether the type contains a lifetime parameter.
     fn has_lifetime(&self) -> bool;
 }
@@ -114,12 +111,6 @@ impl TypeExt for Type {
         let mut infer = InferGeneric::from(stack);
         infer.visit_type_mut(&mut this);
         this
-    }
-
-    fn lifetimes(&self) -> Vec<&Lifetime> {
-        let mut lifetimes = Vec::new();
-        GatherLifetimes(&mut lifetimes).visit_type(self);
-        lifetimes
     }
 
     fn has_lifetime(&self) -> bool {
@@ -782,14 +773,6 @@ impl VisitMut for ReplaceLifetimes<'_> {
     }
 }
 
-struct GatherLifetimes<'a, 'ast>(&'a mut Vec<&'ast Lifetime>);
-
-impl<'ast> Visit<'ast> for GatherLifetimes<'_, 'ast> {
-    fn visit_lifetime(&mut self, l: &'ast Lifetime) {
-        self.0.push(l);
-    }
-}
-
 struct HasLifetime(bool);
 
 impl Visit<'_> for HasLifetime {
@@ -967,17 +950,6 @@ mod tests {
         assert_eq!(iter.nth(25).unwrap().to_string(), "a0");
         assert_eq!(iter.next().unwrap().to_string(), "b0");
         assert_eq!(iter.nth(24).unwrap().to_string(), "a1");
-    }
-
-    #[test]
-    fn test_gather_lifetimes() {
-        let ty: Type = parse_quote!(&'a Foo);
-        let lt: Lifetime = parse_quote!('a);
-        assert_eq!(ty.lifetimes(), vec![&lt]);
-
-        let ty: Type = parse_quote!(&'a Foo<'b, 'c>);
-        let (a, b, c) = (parse_quote!('a), parse_quote!('b), parse_quote!('c));
-        assert_eq!(ty.lifetimes(), vec![&a, &b, &c]);
     }
 
     #[test]

--- a/wincode-derive/src/uninit_builder.rs
+++ b/wincode-derive/src/uninit_builder.rs
@@ -1,5 +1,5 @@
 use {
-    crate::common::{SchemaArgs, TypeExt, extract_repr, get_crate_name},
+    crate::common::{SchemaArgs, extract_repr, get_crate_name},
     darling::{Error, FromDeriveInput, Result, ast::Data},
     proc_macro2::{Span, TokenStream},
     quote::{format_ident, quote},
@@ -151,7 +151,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
     // Generate the helper methods for the builder.
     let builder_helpers = fields.iter().enumerate().map(|(i, field)| {
         let ty = &field.ty;
-        let target_reader_bound = field.target_resolved().with_lifetime("de");
+        let target_reader_bound = field.target_resolved();
         let ident = field.struct_member_ident(i);
         let ident_string = field.struct_member_ident_to_string(i);
         let uninit_mut_ident = format_ident!("uninit_{ident_string}_mut");
@@ -160,21 +160,6 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         let write_uninit_field_ident = format_ident!("write_{ident_string}");
         let assume_init_field_ident = format_ident!("assume_init_{ident_string}");
         let init_with_field_ident = format_ident!("init_{ident_string}_with");
-        let lifetimes = ty.lifetimes();
-        // We must always extract the `Dst` from the type because `SchemaRead` implementations need
-        // not necessarily write to `Self` -- they write to `Self::Dst`, which isn't necessarily `Self`
-        // (e.g., in the case of container types).
-        let field_projection_type = if lifetimes.is_empty() {
-            quote!(<#ty as #crate_name::SchemaRead<'_, __WincodeConfig>>::Dst)
-        } else {
-            let lt = lifetimes[0];
-            // Even though a type may have multiple distinct lifetimes, we force them to be uniform
-            // for a `SchemaRead` cast because an implementation of `SchemaRead` must bind all lifetimes
-            // to the lifetime of the reader (and will not be implemented over multiple distinct lifetimes).
-            let ty = ty.with_lifetime(&lt.ident.to_string());
-            quote!(<#ty as #crate_name::SchemaRead<#lt, __WincodeConfig>>::Dst)
-        };
-
         // The bit index for the field.
         let index_bit = LitInt::new(&(1u128 << i).to_string(), Span::call_site());
         let set_index_bit = quote! {
@@ -184,20 +169,20 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
         quote! {
             /// Get a mutable reference to the maybe uninitialized field.
             #[inline]
-            #vis const fn #uninit_mut_ident(&mut self) -> &mut ::core::mem::MaybeUninit<#field_projection_type> {
+            #vis const fn #uninit_mut_ident(&mut self) -> &mut ::core::mem::MaybeUninit<#ty> {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
-                // - We return the field as `&mut MaybeUninit<#target>`, so
+                // - We return the field as `&mut MaybeUninit<#ty>`, so
                 //   the field is never exposed as initialized.
                 unsafe { &mut *(&raw mut (*self.inner.as_mut_ptr()).#ident).cast() }
             }
 
             /// Get a reference to the maybe uninitialized field.
             #[inline]
-            #vis const fn #uninit_ref_ident(&self) -> &::core::mem::MaybeUninit<#field_projection_type> {
+            #vis const fn #uninit_ref_ident(&self) -> &::core::mem::MaybeUninit<#ty> {
                 // SAFETY:
                 // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
-                // - We return the field as `&MaybeUninit<#target>`, so
+                // - We return the field as `&MaybeUninit<#ty>`, so
                 //   the field is never exposed as initialized.
                 unsafe { &*(&raw const (*self.inner.as_ptr()).#ident).cast() }
             }
@@ -205,7 +190,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
             /// Write a value to the maybe uninitialized field.
             // This method can be marked `const` in the future when MSRV is >= 1.85.
             #[inline]
-            #vis fn #write_uninit_field_ident(&mut self, val: #field_projection_type) -> &mut Self {
+            #vis fn #write_uninit_field_ident(&mut self, val: #ty) -> &mut Self {
                 self.#uninit_mut_ident().write(val);
                 #set_index_bit
                 self
@@ -213,13 +198,14 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
 
             /// Read a value from the reader into the maybe uninitialized field.
             #[inline]
-            #vis fn #read_field_ident <'de>(&mut self, reader: impl #crate_name::io::Reader<'de>) -> #crate_name::ReadResult<&mut Self> {
-                // SAFETY:
-                // - `self.inner` is a valid reference to a `MaybeUninit<#builder_dst>`.
-                // - We return the field as `&mut MaybeUninit<#target>`, so
-                //   the field is never exposed as initialized.
-                let proj = unsafe { &mut *(&raw mut (*self.inner.as_mut_ptr()).#ident).cast() };
-                <#target_reader_bound as #crate_name::SchemaRead<'de, __WincodeConfig>>::read(reader, proj)?;
+            #vis fn #read_field_ident <'de>(&mut self, reader: impl #crate_name::io::Reader<'de>) -> #crate_name::ReadResult<&mut Self>
+            where
+                #target_reader_bound: #crate_name::SchemaRead<'de, __WincodeConfig, Dst = #ty>,
+            {
+                <#target_reader_bound as #crate_name::SchemaRead<'de, __WincodeConfig>>::read(
+                    reader,
+                    self.#uninit_mut_ident(),
+                )?;
                 #set_index_bit
                 Ok(self)
             }
@@ -230,7 +216,7 @@ pub(crate) fn impl_uninit_builder(args: &SchemaArgs, crate_name: &Path) -> Resul
             ///
             /// The caller must guarantee that the initializer function fully initializes the field.
             #[inline]
-            #vis unsafe fn #init_with_field_ident(&mut self, mut initializer: impl FnMut(&mut ::core::mem::MaybeUninit<#field_projection_type>) -> #crate_name::ReadResult<()>) -> #crate_name::ReadResult<&mut Self> {
+            #vis unsafe fn #init_with_field_ident(&mut self, mut initializer: impl FnMut(&mut ::core::mem::MaybeUninit<#ty>) -> #crate_name::ReadResult<()>) -> #crate_name::ReadResult<&mut Self> {
                 initializer(self.#uninit_mut_ident())?;
                 #set_index_bit
                 Ok(self)

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -78,3 +78,73 @@ fn derive_tag_uniqueness_repr_normalization() {}
 /// # }
 /// ```
 fn derive_tag_uniqueness_implicit_collision() {}
+
+/// A `read_<field>` on an `UninitBuilder` must not launder the reader lifetime: reading
+/// from a short-lived reader into a longer-lived borrowed field (here `'static`) would
+/// leave a dangling reference after `assume_init`.
+///
+/// ```compile_fail
+/// # #[cfg(all(feature = "derive"))] {
+/// use {core::mem::MaybeUninit, wincode::config::DefaultConfig};
+///
+/// #[derive(wincode::UninitBuilder)]
+/// struct Borrowed<'a> {
+///     data: &'a [u8],
+/// }
+///
+/// fn launder() -> Borrowed<'static> {
+///     let mut uninit = MaybeUninit::<Borrowed<'static>>::uninit();
+///     {
+///         let short_lived: Vec<u8> = vec![3, 0, 0, 0, 0, 0, 0, 0, 0xAA, 0xBB, 0xCC];
+///         let mut builder =
+///             BorrowedUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+///         builder.read_data(short_lived.as_slice()).unwrap();
+///         builder.finish();
+///     }
+///     unsafe { uninit.assume_init() }
+/// }
+/// # }
+/// ```
+fn uninit_builder_read_forbids_lifetime_launder() {}
+
+/// An `UninitBuilder` reader must write exactly the field type, even when the field's
+/// `SchemaRead` implementation declares a different `Dst`.
+///
+/// ```compile_fail
+/// # #[cfg(all(feature = "derive"))] {
+/// use {
+///     core::mem::MaybeUninit,
+///     wincode::{
+///         ReadResult, SchemaRead,
+///         config::{ConfigCore, DefaultConfig},
+///         io::Reader,
+///     },
+/// };
+///
+/// struct Field;
+/// struct DifferentDst(u64);
+///
+/// unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for Field {
+///     type Dst = DifferentDst;
+///
+///     fn read(
+///         _reader: impl Reader<'de>,
+///         dst: &mut MaybeUninit<Self::Dst>,
+///     ) -> ReadResult<()> {
+///         dst.write(DifferentDst(0));
+///         Ok(())
+///     }
+/// }
+///
+/// #[derive(wincode::UninitBuilder)]
+/// struct HasField {
+///     field: Field,
+/// }
+///
+/// let mut uninit = MaybeUninit::<HasField>::uninit();
+/// let mut builder =
+///     HasFieldUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+/// builder.read_field([].as_slice()).unwrap();
+/// # }
+/// ```
+fn uninit_builder_read_requires_exact_field_dst() {}

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -577,7 +577,7 @@ mod tests {
             containers, context, deserialize, deserialize_exact, deserialize_mut,
             error::{self, invalid_tag_encoding},
             io::{Reader, Writer, test_util::NoBorrowReader},
-            len::{BincodeLen, FixIntLen},
+            len::{BincodeLen, FixIntLen, UseIntLen},
             pod_wrapper,
             proptest_config::proptest_cfg,
             serialize,
@@ -1553,22 +1553,26 @@ mod tests {
 
     #[test]
     fn test_uninit_builder_with_container() {
-        #[derive(UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
+        #[derive(SchemaWrite, UninitBuilder, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
         #[wincode(internal)]
         struct Test {
-            #[wincode(with = "containers::Vec<_, BincodeLen>")]
+            #[wincode(with = "containers::Vec<_, UseIntLen<u16>>")]
             a: Vec<u8>,
             b: [u8; 32],
             c: u64,
         }
 
         proptest!(proptest_cfg(), |(test: Test)| {
+            let serialized = serialize(&test).unwrap();
+            let encoded_len = u16::try_from(test.a.len()).unwrap().to_le_bytes();
+            prop_assert_eq!(&serialized[..encoded_len.len()], &encoded_len);
+            let mut reader = serialized.as_slice();
             let mut uninit = MaybeUninit::<Test>::uninit();
             let mut builder = TestUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
             builder
-                .write_a(test.a.clone())
-                .write_b(test.b)
-                .write_c(test.c);
+                .read_a(reader.by_ref())?
+                .read_b(reader.by_ref())?
+                .read_c(reader)?;
             prop_assert!(builder.is_init());
             let init_mut = unsafe { builder.into_assume_init_mut() };
             prop_assert_eq!(&test, init_mut);
@@ -1605,6 +1609,72 @@ mod tests {
             prop_assert_eq!(test.a.as_slice(), init.a);
             prop_assert_eq!(test.b.as_deref(), init.b);
         });
+    }
+
+    #[test]
+    fn test_uninit_builder_read_borrowed() {
+        #[derive(SchemaWrite, Debug, PartialEq, Eq, proptest_derive::Arbitrary)]
+        #[wincode(internal)]
+        struct Test {
+            a: Vec<u8>,
+            b: Option<String>,
+        }
+
+        #[derive(UninitBuilder, Debug, PartialEq, Eq)]
+        #[wincode(internal)]
+        struct TestRef<'a> {
+            a: &'a [u8],
+            b: Option<&'a str>,
+        }
+
+        proptest!(proptest_cfg(), |(test: Test)| {
+            let serialized = serialize(&test).unwrap();
+            let mut uninit = MaybeUninit::<TestRef>::uninit();
+            let mut reader = serialized.as_slice();
+            let mut builder = TestRefUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+            builder
+                .read_a(reader.by_ref())?
+                .read_b(reader.by_ref())?;
+            prop_assert!(builder.is_init());
+            let init = unsafe { builder.into_assume_init_mut() };
+            prop_assert_eq!(test.a.as_slice(), init.a);
+            prop_assert_eq!(test.b.as_deref(), init.b);
+        });
+    }
+
+    #[test]
+    fn test_uninit_builder_read_owned_with_unrelated_lifetime() {
+        #[derive(UninitBuilder, Debug, PartialEq, Eq)]
+        #[wincode(internal)]
+        struct Test<'a> {
+            marker: PhantomData<&'a ()>,
+            value: u8,
+        }
+
+        fn read_short_lived(reader: &[u8]) -> Test<'static> {
+            let mut uninit = MaybeUninit::<Test<'static>>::uninit();
+            let mut builder =
+                TestUninitBuilder::<DefaultConfig>::from_maybe_uninit_mut(&mut uninit);
+            builder
+                .write_marker(PhantomData)
+                .read_value(reader)
+                .unwrap();
+            builder.finish();
+            // SAFETY: Both fields were initialized by the builder.
+            unsafe { uninit.assume_init() }
+        }
+
+        let short_lived = vec![42];
+        let test = read_short_lived(&short_lived);
+        drop(short_lived);
+
+        assert_eq!(
+            test,
+            Test {
+                marker: PhantomData,
+                value: 42,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Generate field helpers over the struct's actual field type rather than a lifetime-substituted SchemaRead::Dst. Require read_<field> targets to have Dst equal to the stored field type.

This prevents reader lifetime laundering and mismatched-Dst type confusion through the raw field projection, while allowing owned fields to be read without constraints from unrelated struct lifetimes.