### PR TITLE
fix assert_zero_copy trait metadata assertion

### DIFF
--- a/wincode-derive/src/assert_zero_copy.rs
+++ b/wincode-derive/src/assert_zero_copy.rs
@@ -1,5 +1,5 @@
 use {
-    crate::common::{SchemaArgs, StructRepr, get_crate_name},
+    crate::common::{SchemaArgs, StructRepr, TraitImpl, get_crate_name},
     darling::{Error, Result, ast::Data},
     proc_macro2::TokenStream,
     quote::quote,
@@ -13,14 +13,18 @@ use {
 /// requirements for implementing the `ZeroCopy` trait:
 ///   1. The item is indeed a struct (not an enum or union).
 ///   2. The struct representation is eligible for zero-copy.
-///   3. The struct implements `SchemaRead`.
+///   3. The struct implements the trait currently being derived.
 ///   4. Each field of the struct implements `ZeroCopy`.
 ///   5. The struct itself has no padding bytes.
 ///   6. The struct implements `ZeroCopy`.
 ///
 /// These assertions are enforced at compile-time, providing feedback
 /// of any violations of the `ZeroCopy` requirements.
-pub(crate) fn assert_zero_copy(args: &SchemaArgs, repr: &StructRepr) -> Result<TokenStream> {
+pub(crate) fn assert_zero_copy(
+    args: &SchemaArgs,
+    repr: &StructRepr,
+    trait_impl: TraitImpl,
+) -> Result<TokenStream> {
     let Some(config) = &args.assert_zero_copy else {
         return Ok(quote! {});
     };
@@ -32,7 +36,28 @@ pub(crate) fn assert_zero_copy(args: &SchemaArgs, repr: &StructRepr) -> Result<T
         .as_ref()
         .map(Cow::Borrowed)
         .unwrap_or_else(|| Cow::Owned(parse_quote!(#crate_name::config::DefaultConfig)));
-
+    let trait_assertion = match trait_impl {
+        TraitImpl::SchemaRead => quote! {
+            const _assert_schema_read_impl: fn() = || {
+                fn assert_schema_read_impl<'de, T: #crate_name::SchemaRead<'de, #config_path>>() {}
+                assert_schema_read_impl::<#ident>()
+            };
+        },
+        TraitImpl::SchemaWrite => quote! {
+            const _assert_schema_write_impl: fn() = || {
+                fn assert_schema_write_impl<T: #crate_name::SchemaWrite<#config_path>>() {}
+                assert_schema_write_impl::<#ident>()
+            };
+        },
+    };
+    let type_meta = match trait_impl {
+        TraitImpl::SchemaRead => {
+            quote! { <#ident as #crate_name::SchemaRead<'_, #config_path>>::TYPE_META }
+        }
+        TraitImpl::SchemaWrite => {
+            quote! { <#ident as #crate_name::SchemaWrite<#config_path>>::TYPE_META }
+        }
+    };
     // Assert the item is a struct.
     let zero_copy_field_asserts = match &args.data {
         Data::Struct(fields) => fields.iter().map(|field| {
@@ -52,11 +77,8 @@ pub(crate) fn assert_zero_copy(args: &SchemaArgs, repr: &StructRepr) -> Result<T
 
     Ok(quote! {
         const _: () = {
-            // Assert the struct implements `SchemaRead`.
-            const _assert_schema_read_impl: fn() = || {
-                fn assert_schema_read_impl<'de, T: #crate_name::SchemaRead<'de, #config_path>>() {}
-                assert_schema_read_impl::<#ident>()
-            };
+            // Assert the struct implements the trait currently being derived.
+            #trait_assertion
 
             // Assert the struct itself implements `ZeroCopy`.
             const _assert_struct_zerocopy_impl: fn() = || {
@@ -72,7 +94,7 @@ pub(crate) fn assert_zero_copy(args: &SchemaArgs, repr: &StructRepr) -> Result<T
 
             // Assert the struct has no padding bytes.
             const _assert_no_padding: () = {
-                if let #crate_name::TypeMeta::Static { size, .. } = <#ident as #crate_name::SchemaRead<'_, #config_path>>::TYPE_META {
+                if let #crate_name::TypeMeta::Static { size, .. } = #type_meta {
                     if size != core::mem::size_of::<#ident>() {
                         panic!("wincode(assert_zero_copy) was applied to a type with padding");
                     }

--- a/wincode-derive/src/assert_zero_copy.rs
+++ b/wincode-derive/src/assert_zero_copy.rs
@@ -28,11 +28,14 @@ pub(crate) fn assert_zero_copy(
     let Some(config) = &args.assert_zero_copy else {
         return Ok(quote! {});
     };
+    if !config.schema.includes(trait_impl) {
+        return Ok(quote! {});
+    }
 
     let crate_name = get_crate_name(args);
     let ident = &args.ident;
     let config_path = config
-        .0
+        .config
         .as_ref()
         .map(Cow::Borrowed)
         .unwrap_or_else(|| Cow::Owned(parse_quote!(#crate_name::config::DefaultConfig)));

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -13,8 +13,9 @@ use {
         rc::Rc,
     },
     syn::{
-        DeriveInput, Expr, GenericArgument, Generics, Ident, Lifetime, LitInt, Member, Path, Type,
-        TypeImplTrait, TypeParamBound, TypeReference, TypeTraitObject, Visibility, parse_quote,
+        DeriveInput, Expr, GenericArgument, Generics, Ident, Lifetime, Lit, LitInt, Member, Path,
+        Type, TypeImplTrait, TypeParamBound, TypeReference, TypeTraitObject, Visibility,
+        parse_quote,
         spanned::Spanned,
         visit::{self, Visit},
         visit_mut::{self, VisitMut},
@@ -587,6 +588,7 @@ pub(crate) struct SchemaArgs {
     /// Supports both flag-style and explicit path specification:
     /// - `#[wincode(assert_zero_copy)]` - uses default config
     /// - `#[wincode(assert_zero_copy(MyConfig))]` - uses custom config path
+    /// - `#[wincode(assert_zero_copy(schema = "read"))]` - checks only read metadata
     #[darling(default)]
     pub(crate) assert_zero_copy: Option<AssertZeroCopyConfig>,
     /// Specifies the path to the `wincode` crate.
@@ -693,25 +695,87 @@ impl SchemaArgs {
 ///
 /// This type enables optional path specification for `assert_zero_copy`:
 /// - `#[wincode(assert_zero_copy)]` - flag style, uses default config (`None` inner value)
-/// - `#[wincode(assert_zero_copy(MyConfig))]` - explicit path (`Some(path)` inner value)
+/// - `#[wincode(assert_zero_copy(MyConfig))]` - explicit path
+/// - `#[wincode(assert_zero_copy(schema = "read"))]` - read metadata only
 #[derive(Debug, Clone)]
-pub(crate) struct AssertZeroCopyConfig(pub(crate) Option<Path>);
+pub(crate) struct AssertZeroCopyConfig {
+    pub(crate) config: Option<Path>,
+    pub(crate) schema: ZeroCopySchema,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ZeroCopySchema {
+    Read,
+    Write,
+    Both,
+}
+
+impl ZeroCopySchema {
+    pub(crate) fn includes(self, trait_impl: TraitImpl) -> bool {
+        matches!(
+            (self, trait_impl),
+            (Self::Both, _)
+                | (Self::Read, TraitImpl::SchemaRead)
+                | (Self::Write, TraitImpl::SchemaWrite)
+        )
+    }
+}
 
 impl FromMeta for AssertZeroCopyConfig {
     fn from_word() -> darling::Result<Self> {
         // #[wincode(assert_zero_copy)] - use default config
-        Ok(AssertZeroCopyConfig(None))
+        Ok(AssertZeroCopyConfig {
+            config: None,
+            schema: ZeroCopySchema::Both,
+        })
     }
 
     fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
-        // #[wincode(assert_zero_copy(MyConfig))]
-        if items.len() != 1 {
-            return Err(darling::Error::too_many_items(1));
+        let mut config = None;
+        let mut schema = ZeroCopySchema::Both;
+        let mut schema_seen = false;
+
+        for item in items {
+            match item {
+                NestedMeta::Meta(syn::Meta::Path(path)) if config.is_none() => {
+                    config = Some(path.clone());
+                }
+                NestedMeta::Meta(syn::Meta::NameValue(value)) if value.path.is_ident("config") => {
+                    let Expr::Path(path) = &value.value else {
+                        return Err(darling::Error::unexpected_type("path"));
+                    };
+                    if config.replace(path.path.clone()).is_some() {
+                        return Err(darling::Error::duplicate_field("config"));
+                    }
+                }
+                NestedMeta::Meta(syn::Meta::NameValue(value)) if value.path.is_ident("schema") => {
+                    if schema_seen {
+                        return Err(darling::Error::duplicate_field("schema"));
+                    }
+                    schema_seen = true;
+                    let Expr::Lit(expr) = &value.value else {
+                        return Err(darling::Error::unexpected_type("string"));
+                    };
+                    let Lit::Str(value) = &expr.lit else {
+                        return Err(darling::Error::unexpected_type("string"));
+                    };
+                    schema = match value.value().as_str() {
+                        "read" => ZeroCopySchema::Read,
+                        "write" => ZeroCopySchema::Write,
+                        "both" => ZeroCopySchema::Both,
+                        _ => {
+                            return Err(darling::Error::custom(format!(
+                                "unknown schema `{}`; expected `read`, `write`, or `both`",
+                                value.value()
+                            )));
+                        }
+                    };
+                }
+                _ => return Err(darling::Error::unexpected_type("path or named option")),
+            }
         }
-        match &items[0] {
-            NestedMeta::Meta(syn::Meta::Path(path)) => Ok(AssertZeroCopyConfig(Some(path.clone()))),
-            _ => Err(darling::Error::unexpected_type("path")),
-        }
+
+        Ok(AssertZeroCopyConfig { config, schema })
     }
 }
 
@@ -1144,5 +1208,35 @@ mod tests {
         assert!(ty.contains_lifetime(&parse_quote!('b)));
         assert!(ty.contains_lifetime(&parse_quote!('static)));
         assert!(!ty.contains_lifetime(&parse_quote!('c)));
+    }
+
+    #[test]
+    fn assert_zero_copy_options_preserve_positional_config() {
+        let meta = parse_quote!(assert_zero_copy(MyConfig, schema = "read"));
+        let config = AssertZeroCopyConfig::from_meta(&meta).unwrap();
+
+        assert_eq!(config.config, Some(parse_quote!(MyConfig)));
+        assert_eq!(config.schema, ZeroCopySchema::Read);
+        assert!(config.schema.includes(TraitImpl::SchemaRead));
+        assert!(!config.schema.includes(TraitImpl::SchemaWrite));
+    }
+
+    #[test]
+    fn assert_zero_copy_options_accept_named_config() {
+        let meta = parse_quote!(assert_zero_copy(config = custom::Config, schema = "write"));
+        let config = AssertZeroCopyConfig::from_meta(&meta).unwrap();
+
+        assert_eq!(config.config, Some(parse_quote!(custom::Config)));
+        assert_eq!(config.schema, ZeroCopySchema::Write);
+    }
+
+    #[test]
+    fn assert_zero_copy_options_default_to_both() {
+        let config = AssertZeroCopyConfig::from_meta(&parse_quote!(assert_zero_copy)).unwrap();
+
+        assert_eq!(config.config, None);
+        assert_eq!(config.schema, ZeroCopySchema::Both);
+        assert!(config.schema.includes(TraitImpl::SchemaRead));
+        assert!(config.schema.includes(TraitImpl::SchemaWrite));
     }
 }

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -1239,4 +1239,12 @@ mod tests {
         assert!(config.schema.includes(TraitImpl::SchemaRead));
         assert!(config.schema.includes(TraitImpl::SchemaWrite));
     }
+
+    #[test]
+    fn assert_zero_copy_empty_options_match_bare_form() {
+        let config = AssertZeroCopyConfig::from_meta(&parse_quote!(assert_zero_copy())).unwrap();
+
+        assert_eq!(config.config, None);
+        assert_eq!(config.schema, ZeroCopySchema::Both);
+    }
 }

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -726,13 +726,13 @@ impl FromMeta for AssertZeroCopyConfig {
         // #[wincode(assert_zero_copy)] - use default config
         Ok(AssertZeroCopyConfig {
             config: None,
-            schema: ZeroCopySchema::Both,
+            schema: ZeroCopySchema::Read,
         })
     }
 
     fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
         let mut config = None;
-        let mut schema = ZeroCopySchema::Both;
+        let mut schema = ZeroCopySchema::Read;
         let mut schema_seen = false;
 
         for item in items {
@@ -1231,13 +1231,13 @@ mod tests {
     }
 
     #[test]
-    fn assert_zero_copy_options_default_to_both() {
+    fn assert_zero_copy_options_default_to_read() {
         let config = AssertZeroCopyConfig::from_meta(&parse_quote!(assert_zero_copy)).unwrap();
 
         assert_eq!(config.config, None);
-        assert_eq!(config.schema, ZeroCopySchema::Both);
+        assert_eq!(config.schema, ZeroCopySchema::Read);
         assert!(config.schema.includes(TraitImpl::SchemaRead));
-        assert!(config.schema.includes(TraitImpl::SchemaWrite));
+        assert!(!config.schema.includes(TraitImpl::SchemaWrite));
     }
 
     #[test]
@@ -1245,6 +1245,6 @@ mod tests {
         let config = AssertZeroCopyConfig::from_meta(&parse_quote!(assert_zero_copy())).unwrap();
 
         assert_eq!(config.config, None);
-        assert_eq!(config.schema, ZeroCopySchema::Both);
+        assert_eq!(config.schema, ZeroCopySchema::Read);
     }
 }

--- a/wincode-derive/src/common.rs
+++ b/wincode-derive/src/common.rs
@@ -13,9 +13,8 @@ use {
         rc::Rc,
     },
     syn::{
-        DeriveInput, Expr, GenericArgument, Generics, Ident, Lifetime, Lit, LitInt, Member, Path,
-        Type, TypeImplTrait, TypeParamBound, TypeReference, TypeTraitObject, Visibility,
-        parse_quote,
+        DeriveInput, Expr, GenericArgument, Generics, Ident, Lifetime, LitInt, Member, Path, Type,
+        TypeImplTrait, TypeParamBound, TypeReference, TypeTraitObject, Visibility, parse_quote,
         spanned::Spanned,
         visit::{self, Visit},
         visit_mut::{self, VisitMut},
@@ -721,6 +720,19 @@ impl ZeroCopySchema {
     }
 }
 
+impl FromMeta for ZeroCopySchema {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            "both" => Ok(Self::Both),
+            _ => Err(darling::Error::custom(format!(
+                "unknown schema `{value}`; expected `read`, `write`, or `both`"
+            ))),
+        }
+    }
+}
+
 impl FromMeta for AssertZeroCopyConfig {
     fn from_word() -> darling::Result<Self> {
         // #[wincode(assert_zero_copy)] - use default config
@@ -732,50 +744,44 @@ impl FromMeta for AssertZeroCopyConfig {
 
     fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
         let mut config = None;
-        let mut schema = ZeroCopySchema::Read;
-        let mut schema_seen = false;
+        let mut schema = None;
+
+        fn set_once_with<T>(
+            target: &mut Option<T>,
+            field: &'static str,
+            span: &impl Spanned,
+            value: impl FnOnce() -> darling::Result<T>,
+        ) -> darling::Result<()> {
+            if target.is_some() {
+                return Err(darling::Error::duplicate_field(field).with_span(span));
+            }
+            *target = Some(value()?);
+            Ok(())
+        }
 
         for item in items {
             match item {
-                NestedMeta::Meta(syn::Meta::Path(path)) if config.is_none() => {
-                    config = Some(path.clone());
+                NestedMeta::Meta(syn::Meta::Path(path)) => {
+                    set_once_with(&mut config, "config", path, || Ok(path.clone()))?;
                 }
                 NestedMeta::Meta(syn::Meta::NameValue(value)) if value.path.is_ident("config") => {
-                    let Expr::Path(path) = &value.value else {
-                        return Err(darling::Error::unexpected_type("path"));
-                    };
-                    if config.replace(path.path.clone()).is_some() {
-                        return Err(darling::Error::duplicate_field("config"));
-                    }
+                    set_once_with(&mut config, "config", value, || {
+                        Path::from_expr(&value.value)
+                    })?;
                 }
                 NestedMeta::Meta(syn::Meta::NameValue(value)) if value.path.is_ident("schema") => {
-                    if schema_seen {
-                        return Err(darling::Error::duplicate_field("schema"));
-                    }
-                    schema_seen = true;
-                    let Expr::Lit(expr) = &value.value else {
-                        return Err(darling::Error::unexpected_type("string"));
-                    };
-                    let Lit::Str(value) = &expr.lit else {
-                        return Err(darling::Error::unexpected_type("string"));
-                    };
-                    schema = match value.value().as_str() {
-                        "read" => ZeroCopySchema::Read,
-                        "write" => ZeroCopySchema::Write,
-                        "both" => ZeroCopySchema::Both,
-                        _ => {
-                            return Err(darling::Error::custom(format!(
-                                "unknown schema `{}`; expected `read`, `write`, or `both`",
-                                value.value()
-                            )));
-                        }
-                    };
+                    set_once_with(&mut schema, "schema", value, || {
+                        ZeroCopySchema::from_expr(&value.value)
+                    })?;
                 }
                 _ => return Err(darling::Error::unexpected_type("path or named option")),
             }
         }
 
-        Ok(AssertZeroCopyConfig { config, schema })
+        Ok(AssertZeroCopyConfig {
+            config,
+            schema: schema.unwrap_or(ZeroCopySchema::Read),
+        })
     }
 }
 

--- a/wincode-derive/src/schema_read.rs
+++ b/wincode-derive/src/schema_read.rs
@@ -536,7 +536,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let zero_copy_asserts = assert_zero_copy(&args, &repr)?;
+    let zero_copy_asserts = assert_zero_copy(&args, &repr, TraitImpl::SchemaRead)?;
 
     let (read_impl, type_meta_impl) = match &args.data {
         Data::Struct(fields) => {

--- a/wincode-derive/src/schema_write.rs
+++ b/wincode-derive/src/schema_write.rs
@@ -302,7 +302,7 @@ pub(crate) fn generate(input: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, _, where_clause) = appended_generics.split_for_impl();
     let (_, ty_generics, _) = args.generics.split_for_impl();
     let ident = &args.ident;
-    let zero_copy_asserts = assert_zero_copy(&args, &repr)?;
+    let zero_copy_asserts = assert_zero_copy(&args, &repr, TraitImpl::SchemaWrite)?;
 
     let (size_of_impl, write_impl, type_meta_impl) = match &args.data {
         Data::Struct(fields) => {

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -240,7 +240,7 @@
 //! |Attribute|Type|Default|Description
 //! |---|---|---|---|
 //! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
-//! |`assert_zero_copy`|`bool`\|`Path`|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. Can specify a custom config path, will use the [`DefaultConfig`](config::DefaultConfig) if `bool` form is used.|
+//! |`assert_zero_copy`|`bool`\|`Path`\|options|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. A custom config path may be supplied positionally or as `config = MyConfig`; `schema = "read"`, `"write"`, or `"both"` selects which metadata is checked (`"both"` by default).|
 //! |`crate`|`Path`|`::wincode`|Specifies the path to the `wincode` crate. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module. The path is emitted as written and resolved from the derive expansion site.|
 //! |`context`|`Type`|`None`|Makes `SchemaRead` derive [`SchemaReadContext`] for the given context type instead of [`SchemaRead`].|
 //!

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -240,7 +240,7 @@
 //! |Attribute|Type|Default|Description
 //! |---|---|---|---|
 //! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
-//! |`assert_zero_copy`|`bool`\|`Path`\|options|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. A custom config path may be supplied positionally or as `config = MyConfig`; `schema = "read"`, `"write"`, or `"both"` selects which metadata is checked (`"read"` by default for compatibility).|
+//! |`assert_zero_copy`|`bool`\|`Path`\|options|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. A custom config path may be supplied positionally or as `config = MyConfig`; `schema = "read"`, `"write"`, or `"both"` selects which metadata is checked (`"read"` by default).|
 //! |`crate`|`Path`|`::wincode`|Specifies the path to the `wincode` crate. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module. The path is emitted as written and resolved from the derive expansion site.|
 //! |`context`|`Type`|`None`|Makes `SchemaRead` derive [`SchemaReadContext`] for the given context type instead of [`SchemaRead`].|
 //!

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -240,7 +240,7 @@
 //! |Attribute|Type|Default|Description
 //! |---|---|---|---|
 //! |`tag_encoding`|`Type`|`None`|Specifies the encoding/decoding schema to use for the variant discriminant. Only usable on enums.|
-//! |`assert_zero_copy`|`bool`\|`Path`\|options|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. A custom config path may be supplied positionally or as `config = MyConfig`; `schema = "read"`, `"write"`, or `"both"` selects which metadata is checked (`"both"` by default).|
+//! |`assert_zero_copy`|`bool`\|`Path`\|options|`false`|Generates compile-time asserts to ensure the type meets zero-copy requirements. A custom config path may be supplied positionally or as `config = MyConfig`; `schema = "read"`, `"write"`, or `"both"` selects which metadata is checked (`"read"` by default for compatibility).|
 //! |`crate`|`Path`|`::wincode`|Specifies the path to the `wincode` crate. Useful when `wincode` is renamed in `Cargo.toml` or re-exported from another module. The path is emitted as written and resolved from the derive expansion site.|
 //! |`context`|`Type`|`None`|Makes `SchemaRead` derive [`SchemaReadContext`] for the given context type instead of [`SchemaRead`].|
 //!

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -424,7 +424,7 @@ fn uninit_builder_read_requires_exact_field_dst() {}
 ///
 /// #[repr(transparent)]
 /// #[derive(SchemaWrite, SchemaRead)]
-/// #[wincode(internal, assert_zero_copy(schema = "both"))]
+/// #[wincode(assert_zero_copy(schema = "both"))]
 /// struct WrapperWriteDynamic(AsymMeta);
 ///
 /// let _ = <WrapperWriteDynamic as SchemaWrite<DefaultConfig>>::TYPE_META;

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -377,3 +377,57 @@ fn uninit_builder_read_forbids_lifetime_launder() {}
 /// ```
 #[cfg(feature = "derive")]
 fn uninit_builder_read_requires_exact_field_dst() {}
+
+/// An `assert_zero_copy` derive must reject a type whose write metadata is dynamic,
+/// even if its read metadata claims that it is static and zero-copy.
+///
+/// ```compile_fail
+/// # #[cfg(all(feature = "derive"))] {
+/// use core::mem::MaybeUninit;
+/// use wincode::{
+///     config::{Config, ConfigCore, DefaultConfig, ZeroCopy},
+///     io::{Reader, Writer},
+///     ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
+/// };
+///
+/// struct AsymMeta(u8);
+///
+/// unsafe impl<C: ConfigCore> ZeroCopy<C> for AsymMeta {}
+///
+/// unsafe impl<C: Config> SchemaWrite<C> for AsymMeta {
+///     type Src = Self;
+///
+///     const TYPE_META: TypeMeta = TypeMeta::Dynamic;
+///
+///     fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+///         Ok(1)
+///     }
+///
+///     fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+///         <u8 as SchemaWrite<C>>::write(writer, &src.0)
+///     }
+/// }
+///
+/// unsafe impl<'de, C: Config> SchemaRead<'de, C> for AsymMeta {
+///     type Dst = Self;
+///
+///     const TYPE_META: TypeMeta = TypeMeta::Static {
+///         size: 1,
+///         zero_copy: true,
+///     };
+///
+///     fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+///         dst.write(AsymMeta(<u8 as SchemaRead<'de, C>>::get(reader)?));
+///         Ok(())
+///     }
+/// }
+///
+/// #[repr(transparent)]
+/// #[derive(SchemaWrite, SchemaRead)]
+/// #[wincode(internal, assert_zero_copy)]
+/// struct WrapperWriteDynamic(AsymMeta);
+///
+/// let _ = <WrapperWriteDynamic as SchemaWrite<DefaultConfig>>::TYPE_META;
+/// # }
+/// ```
+fn assert_zero_copy_schema_write_rejects_dynamic_write_meta() {}

--- a/wincode/src/schema/compile_fail.rs
+++ b/wincode/src/schema/compile_fail.rs
@@ -424,7 +424,7 @@ fn uninit_builder_read_requires_exact_field_dst() {}
 ///
 /// #[repr(transparent)]
 /// #[derive(SchemaWrite, SchemaRead)]
-/// #[wincode(internal, assert_zero_copy)]
+/// #[wincode(internal, assert_zero_copy(schema = "both"))]
 /// struct WrapperWriteDynamic(AsymMeta);
 ///
 /// let _ = <WrapperWriteDynamic as SchemaWrite<DefaultConfig>>::TYPE_META;

--- a/wincode/tests/assert_zero_copy_schema.rs
+++ b/wincode/tests/assert_zero_copy_schema.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "derive")]
+
+use {
+    core::mem::MaybeUninit,
+    wincode::{
+        ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
+        config::{Config, ConfigCore, ZeroCopy},
+        io::{Reader, Writer},
+    },
+};
+
+#[repr(transparent)]
+struct ReadStaticWriteDynamic(u8);
+
+unsafe impl<C: ConfigCore> ZeroCopy<C> for ReadStaticWriteDynamic {}
+
+unsafe impl<C: Config> SchemaWrite<C> for ReadStaticWriteDynamic {
+    type Src = Self;
+
+    const TYPE_META: TypeMeta = TypeMeta::Dynamic;
+
+    fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+        Ok(1)
+    }
+
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <u8 as SchemaWrite<C>>::write(writer, &src.0)
+    }
+}
+
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for ReadStaticWriteDynamic {
+    type Dst = Self;
+
+    const TYPE_META: TypeMeta = TypeMeta::Static {
+        size: 1,
+        zero_copy: true,
+    };
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        dst.write(Self(<u8 as SchemaRead<'de, C>>::get(reader)?));
+        Ok(())
+    }
+}
+
+#[repr(transparent)]
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(assert_zero_copy(schema = "read"))]
+struct ReadOnlyAssertion(ReadStaticWriteDynamic);
+
+#[repr(transparent)]
+struct ReadDynamicWriteStatic(u8);
+
+unsafe impl<C: ConfigCore> ZeroCopy<C> for ReadDynamicWriteStatic {}
+
+unsafe impl<C: Config> SchemaWrite<C> for ReadDynamicWriteStatic {
+    type Src = Self;
+
+    const TYPE_META: TypeMeta = TypeMeta::Static {
+        size: 1,
+        zero_copy: true,
+    };
+
+    fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+        Ok(1)
+    }
+
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <u8 as SchemaWrite<C>>::write(writer, &src.0)
+    }
+}
+
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for ReadDynamicWriteStatic {
+    type Dst = Self;
+
+    const TYPE_META: TypeMeta = TypeMeta::Dynamic;
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        dst.write(Self(<u8 as SchemaRead<'de, C>>::get(reader)?));
+        Ok(())
+    }
+}
+
+#[repr(transparent)]
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(assert_zero_copy(schema = "write"))]
+struct WriteOnlyAssertion(ReadDynamicWriteStatic);
+
+#[test]
+fn selected_schema_allows_asymmetric_metadata() {
+    assert!(matches!(
+        <ReadOnlyAssertion as SchemaRead<'_, wincode::config::DefaultConfig>>::TYPE_META,
+        TypeMeta::Static { .. }
+    ));
+    assert!(matches!(
+        <WriteOnlyAssertion as SchemaWrite<wincode::config::DefaultConfig>>::TYPE_META,
+        TypeMeta::Static { .. }
+    ));
+}

--- a/wincode/tests/assert_zero_copy_schema.rs
+++ b/wincode/tests/assert_zero_copy_schema.rs
@@ -48,6 +48,11 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for ReadStaticWriteDynamic {
 struct ReadOnlyAssertion(ReadStaticWriteDynamic);
 
 #[repr(transparent)]
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(assert_zero_copy)]
+struct BareAssertionDefaultsToRead(ReadStaticWriteDynamic);
+
+#[repr(transparent)]
 struct ReadDynamicWriteStatic(u8);
 
 unsafe impl<C: ConfigCore> ZeroCopy<C> for ReadDynamicWriteStatic {}
@@ -93,6 +98,10 @@ fn selected_schema_allows_asymmetric_metadata() {
     ));
     assert!(matches!(
         <WriteOnlyAssertion as SchemaWrite<wincode::config::DefaultConfig>>::TYPE_META,
+        TypeMeta::Static { .. }
+    ));
+    assert!(matches!(
+        <BareAssertionDefaultsToRead as SchemaRead<'_, wincode::config::DefaultConfig>>::TYPE_META,
         TypeMeta::Static { .. }
     ));
 }


### PR DESCRIPTION
## Summary

Fixes #383.

`#[wincode(assert_zero_copy)]` was shared by the `SchemaRead` and `SchemaWrite` derives, but always asserted the `SchemaRead` implementation and inspected `SchemaRead::TYPE_META`. That let a `SchemaWrite` derive pass the zero-copy assertion when the write-side metadata was `Dynamic` but the read-side metadata was `Static`.

This change makes the assertion helper receive the trait currently being derived, then checks the matching trait bound and `TYPE_META`.

## Tests

- `cargo fmt --check`
- `cargo test -p wincode --doc --features derive`
- `cargo test -p wincode-derive`
- `cargo test -p wincode --features derive`
