### PR TITLE
chore(ctx): derive Copy + others on context::Len

### DIFF
--- a/wincode/src/schema/context.rs
+++ b/wincode/src/schema/context.rs
@@ -70,4 +70,5 @@
 /// let deserialized = wincode::deserialize(&bytes).unwrap();
 /// assert_eq!(data, deserialized);
 /// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Len(pub usize);


### PR DESCRIPTION
`context::Len` doesn't implement `Copy`. This prevents it being used in the `SchemaReadContext` derive multiple times. Probably a niche use-case, but no reason not to support it.