### PR TITLE
docs: clarify serialize_into partial writes

### DIFF
--- a/wincode/src/config/serde.rs
+++ b/wincode/src/config/serde.rs
@@ -29,6 +29,19 @@ pub trait Serialize<C: Config>: SchemaWrite<C> {
     }
 
     /// Serialize a serializable type into the given [`Writer`].
+    ///
+    /// # Partial writes
+    ///
+    /// This operation is not transactional. If it returns an error, the writer
+    /// may already contain a prefix of the serialized value. Dynamically sized
+    /// values in particular may discover insufficient capacity only after
+    /// preceding fields have been written.
+    ///
+    /// If the destination must remain unchanged on failure, serialize into a
+    /// temporary buffer and copy the result only after serialization succeeds.
+    /// For a fixed-size destination, callers can instead use
+    /// [`Self::serialized_size`] with the same configuration to check that
+    /// enough space is available first.
     #[inline]
     #[expect(unused_variables)]
     fn serialize_into(mut dst: impl Writer, src: &Self::Src, config: C) -> WriteResult<()> {
@@ -114,6 +127,9 @@ where
 }
 
 /// Like [`crate::serialize_into`], but allows the caller to provide a custom configuration.
+///
+/// This has the same non-transactional, partial-write behavior documented by
+/// [`crate::serialize_into`].
 #[inline]
 pub fn serialize_into<T, C: Config>(dst: impl Writer, src: &T, config: C) -> WriteResult<()>
 where

--- a/wincode/src/serde.rs
+++ b/wincode/src/serde.rs
@@ -110,6 +110,18 @@ pub trait Serialize: SchemaWrite<DefaultConfig> {
     }
 
     /// Serialize a serializable type into the given byte buffer.
+    ///
+    /// # Partial writes
+    ///
+    /// This operation is not transactional. If it returns an error, the writer
+    /// may already contain a prefix of the serialized value. Dynamically sized
+    /// values in particular may discover insufficient capacity only after
+    /// preceding fields have been written.
+    ///
+    /// If the destination must remain unchanged on failure, serialize into a
+    /// temporary buffer and copy the result only after serialization succeeds.
+    /// For a fixed-size destination, callers can instead use
+    /// [`Self::serialized_size`] to check that enough space is available first.
     #[inline]
     fn serialize_into(dst: impl Writer, src: &Self::Src) -> WriteResult<()> {
         <Self as config::Serialize<DefaultConfig>>::serialize_into(
@@ -312,6 +324,18 @@ where
 /// Serialize a type into the given writer.
 ///
 /// Like [`serialize`], but allows the caller to provide their own writer.
+///
+/// # Partial writes
+///
+/// This operation is not transactional. If it returns an error, `dst` may
+/// already contain a prefix of the serialized value. Dynamically sized values
+/// in particular may discover insufficient capacity only after preceding
+/// fields have been written.
+///
+/// If the destination must remain unchanged on failure, serialize into a
+/// temporary buffer and copy the result only after serialization succeeds. For
+/// a fixed-size destination, callers can instead use [`serialized_size`] to
+/// check that enough space is available first.
 #[inline]
 pub fn serialize_into<T>(dst: impl Writer, src: &T) -> WriteResult<()>
 where


### PR DESCRIPTION
## Summary

- document that `serialize_into` is non-transactional and may partially update its writer before returning an error
- call out dynamically sized values as a case where insufficient capacity may only be discovered after earlier fields are written
- document two caller-side strategies when the destination must remain unchanged: serialize to a temporary buffer, or preflight a fixed-size destination with `serialized_size`
- apply the clarification to both default and configuration-aware entry points

## Context

The first revision in #419 changed dynamic writes to preflight their full size. Based on the maintainer feedback in #418 that the existing behavior is intentional and explicit documentation is reasonable, this replacement removes that behavior change and is documentation-only.

## Testing

- `cargo fmt --all -- --check` (Rust 1.89 Linux container)
- `cargo test --all-features --doc --no-fail-fast --workspace` (83 passed, 6 ignored)

Fixes #418
