### PR TITLE
chore(ci): fuzz-upload-action v2.1.0

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./fuzz/build-fuzz-bundle.sh
 
       - name: Upload corpus to FuzzCorp
-        uses: asymmetric-research/fuzz-upload-action@0e367cafdc501772fd0fd7dc13bfa68d49222256 # v2.0.0
+        uses: asymmetric-research/fuzz-upload-action@d81375ddc1887ddf574713845dcfada9d3968edc # v2.1.0
         with:
           upload_type: corpus
           upload_path: ./fuzz/corpus/roundtrip
@@ -39,7 +39,7 @@ jobs:
           FUZZ_API_KEY: ${{ secrets.FUZZ_API_KEY }}
 
       - name: Upload bundle to FuzzCorp
-        uses: asymmetric-research/fuzz-upload-action@0e367cafdc501772fd0fd7dc13bfa68d49222256 # v2.0.0
+        uses: asymmetric-research/fuzz-upload-action@d81375ddc1887ddf574713845dcfada9d3968edc # v2.1.0
         with:
           upload_type: bundle
           upload_path: ./fuzz/target/bundle


### PR DESCRIPTION
Update the 'fuzz-upload-action' commit sha to the [latest release](https://github.com/asymmetric-research/fuzz-upload-action/releases/tag/v2.1.0)

We changed how the action verifies the `fuzz-up` binary, so pre-v2.1.0 workflows will no longer work.

Updated here too:
- https://github.com/anza-xyz/sbpf/pull/210