### PR TITLE
Bump wincode to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bincode",
  "bumpalo",

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode"
-version = "0.6.0"
+version = "0.6.1"
 authors.workspace = true
 description = "Fast bincode de/serialization with placement initialization"
 repository.workspace = true
@@ -43,7 +43,7 @@ indexmap = { version = "2.13.1", optional = true, default-features = false }
 pastey = "0.2.2"
 smallvec = { version = "1.15.1", optional = true, default-features = false, features = ["const_generics"] }
 thiserror = { version = "2.0.18", default-features = false }
-wincode-derive = { path = "../wincode-derive", version = "0.5.0", optional = true }
+wincode-derive = { path = "../wincode-derive", version = "0.5.1", optional = true }
 uuid = { version = "1.23.1", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Includes:
- https://github.com/anza-xyz/wincode/pull/403
- https://github.com/anza-xyz/wincode/pull/409
- https://github.com/anza-xyz/wincode/pull/420
- wincode-derive 0.5.1


