### PR TITLE
refactor(schema): validate `String` UTF-8 before allocating

### DIFF
--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -1120,9 +1120,19 @@ unsafe impl<'de, C: Config> SchemaReadContext<'de, C, context::Len> for String {
     #[inline]
     fn read_with_context(
         ctx: context::Len,
-        reader: impl Reader<'de>,
+        mut reader: impl Reader<'de>,
         dst: &mut MaybeUninit<Self::Dst>,
     ) -> ReadResult<()> {
+        // Readers backed by memory can hand us the bytes directly, letting a bad
+        // length or bad UTF-8 fail before we allocate. We only borrow temporarily,
+        // to copy into the `String`.
+        if reader.supports_borrow(BorrowKind::CallSite) {
+            let bytes = reader.take_scoped(ctx.0)?;
+            let s = core::str::from_utf8(bytes).map_err(invalid_utf8_encoding)?;
+            dst.write(s.into());
+            return Ok(());
+        }
+
         let bytes = <Vec<u8> as SchemaReadContext<C, _>>::get_with_context(ctx, reader)?;
         match String::from_utf8(bytes) {
             Ok(s) => {

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -3308,6 +3308,11 @@ mod tests {
             let schema_deserialized: String = deserialize(&schema_serialized).unwrap();
             prop_assert_eq!(&str, &bincode_deserialized);
             prop_assert_eq!(&str, &schema_deserialized);
+
+            // The above borrows from the reader; this exercises the copying path.
+            let schema_deserialized = <String as SchemaRead<DefaultConfig>>
+                ::get(NoBorrowReader::new(&schema_serialized)).unwrap();
+            prop_assert_eq!(&str, &schema_deserialized);
         }
 
         #[test]
@@ -4845,6 +4850,19 @@ mod tests {
             prop_assert_eq!(&deserialized, &bincode_deserialized);
             prop_assert_eq!(value, deserialized);
         });
+    }
+
+    /// Both the borrowing and the copying path must reject invalid UTF-8.
+    #[test]
+    fn test_string_invalid_utf8() {
+        let mut serialized = serialize(&String::from("ab")).unwrap();
+        // Corrupt the payload into a byte that can never appear in UTF-8.
+        *serialized.last_mut().unwrap() = 0xFF;
+
+        assert!(deserialize::<String>(&serialized).is_err());
+        assert!(
+            <String as SchemaRead<DefaultConfig>>::get(NoBorrowReader::new(&serialized)).is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Readers backed by memory can hand out the bytes directly, so an invalid length or invalid UTF-8 now fails without allocating first. 

#### Summary of Changes
If borrowing is available, borrow and validate using `str`'s function before creating `Vec` / `String` out of it. Valid input does the same work as before, but invalid input may skip allocation.

Fixes #430 

#### Testing
Added positive and negative tests for the new reader modes.